### PR TITLE
Fix typo in VISPA example

### DIFF
--- a/examples/htcondor_at_vispa/README.md
+++ b/examples/htcondor_at_vispa/README.md
@@ -1,6 +1,6 @@
 # Example: HTCondor workflows at VISPA
 
-This example demonstrates how to create law task workflows that run on the HTCondor batch system at [VISPA](vispa.physik.rwth-aachen.de).
+This example demonstrates how to create law task workflows that run on the HTCondor batch system at [VISPA](https://vispa.physik.rwth-aachen.de/).
 
 The actual payload of the tasks is rather trivial. The workflow consists of 26 tasks which convert an integer between 97 and 122 (ascii) into a character. A single task collects the results in the end and writes all characters into a text file.
 

--- a/examples/htcondor_at_vispa/analysis/framework.py
+++ b/examples/htcondor_at_vispa/analysis/framework.py
@@ -45,7 +45,7 @@ class HTCondorWorkflow(law.contrib.htcondor.HTCondorWorkflow):
     configuration is required.
     """
 
-    htcondor_gpus = luigi.IntParameter(default=law.NO_INT, significant=False, desription="number "
+    htcondor_gpus = luigi.IntParameter(default=law.NO_INT, significant=False, description="number "
         "of GPUs to request on the VISPA cluster, leave empty to use only CPUs")
 
     def htcondor_output_directory(self):


### PR DESCRIPTION
Python 3 will fail due to a wrong keyword argument.