### PR TITLE
Improve Python 3 compatibility

### DIFF
--- a/law/contrib/arc/job.py
+++ b/law/contrib/arc/job.py
@@ -298,7 +298,7 @@ class ArcJobFileFactory(BaseJobFileFactory):
                         src = ""
             return (path, src, opts) if opts else (path, src)
 
-        c.input_files = map(prepare_input, c.input_files)
+        c.input_files = list(map(prepare_input, c.input_files))
 
         # postfix the executable
         pf_executable = self.postfix_file(os.path.basename(c.executable), postfix)

--- a/law/contrib/glite/job.py
+++ b/law/contrib/glite/job.py
@@ -269,7 +269,7 @@ class GLiteJobFileFactory(BaseJobFileFactory):
             path = add_scheme(path, "file") if c.absolute_paths else os.path.basename(path)
             return path
 
-        c.input_files = map(prepare_input, c.input_files)
+        c.input_files = list(map(prepare_input, c.input_files))
 
         # ensure that log files are contained in the output files
         if c.stdout and c.stdout not in c.output_files:

--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -325,7 +325,7 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
             path = path if c.absolute_paths else os.path.basename(path)
             return path
 
-        c.input_files = map(prepare_input, c.input_files)
+        c.input_files = list(map(prepare_input, c.input_files))
 
         # output files
         if c.postfix_output_files:

--- a/law/contrib/lsf/job.py
+++ b/law/contrib/lsf/job.py
@@ -235,7 +235,7 @@ class LSFJobFileFactory(BaseJobFileFactory):
             path = path if c.absolute_paths else os.path.basename(path)
             return path
 
-        c.input_files = map(prepare_input, c.input_files)
+        c.input_files = list(map(prepare_input, c.input_files))
 
         # output files
         if c.postfix_output_files:

--- a/law/job/base.py
+++ b/law/job/base.py
@@ -366,7 +366,10 @@ class JobArguments(object):
 
     @classmethod
     def encode_list(cls, value):
-        return base64.b64encode(" ".join(str(v) for v in value) or "-")
+        encoded = base64.b64encode(six.b(" ".join(str(v) for v in value) or "-"))
+        if six.PY3:
+            return encoded.decode("utf-8")
+        return encoded
 
     def pack(self):
         return [

--- a/law/util.py
+++ b/law/util.py
@@ -24,13 +24,15 @@ import signal
 import hashlib
 import shutil
 import copy
-from collections import OrderedDict
+from collections import OrderedDict, ValuesView
 from contextlib import contextmanager
 
 import six
 
 
 class NoValue(object):
+    def __bool__(self):
+        return False
 
     def __nonzero__(self):
         return False
@@ -217,7 +219,7 @@ def flatten(struct):
         return flatten(list(struct))
     elif isinstance(struct, dict):
         return flatten(struct.values())
-    elif isinstance(struct, (list, tuple, set)):
+    elif isinstance(struct, (list, tuple, set, ValuesView)):
         objs = []
         for obj in struct:
             objs.extend(flatten(obj))

--- a/law/workflow/base.py
+++ b/law/workflow/base.py
@@ -207,7 +207,7 @@ class BaseWorkflow(Task):
 
         # reset end_branch
         if self.end_branch < 0:
-            self.end_branch = sys.maxint
+            self.end_branch = sys.maxsize
         self.end_branch = max(self.start_branch, min(max_branch + 1, self.end_branch))
 
     def _reduce_branch_map(self):

--- a/law/workflow/remote.py
+++ b/law/workflow/remote.py
@@ -304,7 +304,7 @@ class BaseRemoteWorkflowProxy(BaseWorkflowProxy):
 
         # fill with jobs from the waiting list until maximum number of parallel jobs is reached
         n_active = self.n_active_jobs or 0
-        n_parallel = sys.maxint if task.parallel_jobs < 0 else task.parallel_jobs
+        n_parallel = sys.maxsize if task.parallel_jobs < 0 else task.parallel_jobs
         new_jobs = OrderedDict()
         for job_num, branches in six.iteritems(self.submission_data.waiting_jobs):
             if n_active + len(new_jobs) >= n_parallel:
@@ -388,11 +388,11 @@ class BaseRemoteWorkflowProxy(BaseWorkflowProxy):
 
         # determine thresholds
         if is_no_param(task.walltime):
-            max_polls = sys.maxint
+            max_polls = sys.maxsize
         else:
             max_polls = int(math.ceil((task.walltime * 3600.) / (task.poll_interval * 60.)))
         n_poll_fails = 0
-        n_parallel = sys.maxint if task.parallel_jobs < 0 else task.parallel_jobs
+        n_parallel = sys.maxsize if task.parallel_jobs < 0 else task.parallel_jobs
         n_finished_min = task.acceptance * n_jobs if task.acceptance <= 1 else task.acceptance
         n_failed_max = task.tolerance * n_jobs if task.tolerance <= 1 else task.tolerance
 


### PR DESCRIPTION
A few minor fixes to make the VISPA example work together with Python 3.

Main changes:
- Replace `sys.maxint` with `sys.maxsize` since it was removed in Python 3
- Fix `utils.flatten` since `OrderedDict.values()` now returns a `ValuesView` instead of a `list`
- Convert `input_files` to list
- Explicitly handle bytes in `encode_list`