### PR TITLE
Show help message if law CLI executes without command

### DIFF
--- a/law/cli/cli.py
+++ b/law/cli/cli.py
@@ -31,4 +31,7 @@ def run():
     else:
         args = parser.parse_args()
 
-    mods[args.command].execute(args)
+    if args.command:
+        mods[args.command].execute(args)
+    else:
+        parser.print_help()


### PR DESCRIPTION
This prevents errors if a user runs the law CLI on Python 3 without a command.

## master
```bash
> law
Traceback (most recent call last):
  File "/home/lgeiger/miniconda3/bin/law", line 11, in <module>
    load_entry_point('law', 'console_scripts', 'law')()
  File "/home/lgeiger/law/law/cli/cli.py", line 34, in run
    mods[args.command].execute(args)
KeyError: None
```

## PR
```bash
> law
usage: law [-h] {run,db,config,software,completion} ...

law command line tool

positional arguments:
  {run,db,config,software,completion}
                        subcommands

optional arguments:
  -h, --help            show this help message and exit
```