### PR TITLE
JSONFormatter: Rename cls argument to allow for custom Encoder

### DIFF
--- a/law/target/formatter.py
+++ b/law/target/formatter.py
@@ -116,12 +116,12 @@ class JSONFormatter(Formatter):
         return get_path(path).endswith(".json")
 
     @classmethod
-    def load(cls, path, *args, **kwargs):
+    def load(cls_, path, *args, **kwargs):
         with open(get_path(path), "r") as f:
             return json.load(f, *args, **kwargs)
 
     @classmethod
-    def dump(cls, path, obj, *args, **kwargs):
+    def dump(cls_, path, obj, *args, **kwargs):
         with open(get_path(path), "w") as f:
             return json.dump(obj, f, *args, **kwargs)
 


### PR DESCRIPTION
`json.dump` and `json.load` allow to use a custom [Encoder/Decoder via the `cls` keyword argument](https://docs.python.org/3/library/json.html#json.dump).

Unfortunately this conflicts with the PEP8 naming convention of class methods resulting in a type error: `TypeError: dump() got multiple values for argument 'cls'`.

This PR renames `cls` to `cls_` for the affected class methods.