### PR TITLE
Include wrapper tasks in law db

### DIFF
--- a/law/cli/db.py
+++ b/law/cli/db.py
@@ -82,9 +82,12 @@ def execute(args):
             continue
         seen_families.append(cls.task_family)
 
-        skip = cls.exclude_db or not callable(getattr(cls, "run", None)) \
-            or getattr(cls.run, "__isabstractmethod__", False)
-        if not skip:
+        is_valid_task = (callable(getattr(cls, "run", None)) and
+            not getattr(cls.run, "__isabstractmethod__", False)) or \
+            (callable(getattr(cls, "complete", None)) and
+            not getattr(cls.complete, "__isabstractmethod__", False))
+
+        if not cls.exclude_db and is_valid_task:
             task_classes.append(cls)
 
     def get_task_params(cls):

--- a/law/sandbox/base.py
+++ b/law/sandbox/base.py
@@ -294,6 +294,7 @@ class SandboxTask(Task):
 
     valid_sandboxes = ["*"]
 
+    exclude_db = True
     exclude_params_sandbox = {"print_deps", "print_status", "remove_output", "sandbox"}
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Wrapper tasks are ignored in law db because they don't implement a run method.

This PR whitelists wrapper tasks if a complete method exists.
Alternatively we could check if it inherits from `law.WrapperTask` to be more rigorous but then users are forced to inherit from `law.WrapperTask` when writing custom complete methods.