### PR TITLE
Fix implementation of WrapperTask and ExternalTask

### DIFF
--- a/law/task/base.py
+++ b/law/task/base.py
@@ -291,13 +291,17 @@ class Task(BaseTask):
 
 
 class WrapperTask(Task):
-
-    run = None
-
+    """
+    Use for tasks that only wrap other tasks and that by definition are done
+    if all their requirements exist.
+    """
     exclude_db = True
 
     def complete(self):
         return all(task.complete() for task in flatten(self.requires()))
+
+    def run(self):
+        return
 
 
 class ProxyTask(BaseTask):


### PR DESCRIPTION
## Problem
[`luigi` treats tasks without a `run` method as external Tasks](https://github.com/spotify/luigi/blob/636a0203f650688c4ce249a994c1d6169e5a16af/luigi/worker.py#L85) and therefor won't run them if dependencies are missing.

## Proposed Solution
This PR fixes the implementation of `WrapperTask` to match `luigi`: see [`luigi.WrapperTask`](https://github.com/spotify/luigi/blob/master/luigi/task.py#L800) and [`luigi.Task::run()`](https://github.com/spotify/luigi/blob/master/luigi/task.py#L636).

I also added the `ExternalTask` class the [same way as defined in luigi](https://github.com/spotify/luigi/blob/master/luigi/task.py#L726) and modified `law.cli.db` to include external tasks in the completions.