### PR TITLE
Add context for npz to avoid file descriptor leakage

### DIFF
--- a/law/contrib/numpy/formatter.py
+++ b/law/contrib/numpy/formatter.py
@@ -28,7 +28,15 @@ class NumpyFormatter(Formatter):
         import numpy as np
 
         path = get_path(path)
-        func = np.loadtxt if path.endswith(".txt") else np.load
+        if path.endswith(".txt"):
+            func = np.loadtxt
+        elif path.endswith(".npz"):
+            def load_with_context(*args, **kwargs):
+                with np.load(*args, **kwargs) as npz_file:
+                    return {key: npz_file[key] for key in npz_file.keys()}
+            func = load_with_context
+        else:
+            func = np.load
         return func(path, *args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
According to the [numpy.load documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html) (see `Returns:` section) a context should be used when opening `.npz` files to avoid file descriptor leakage.