### PR TITLE
Add HDF5 Formatter

### DIFF
--- a/docs/contrib/hdf5.rst
+++ b/docs/contrib/hdf5.rst
@@ -1,0 +1,13 @@
+hdf5
+====
+
+.. automodule:: law.contrib.hdf5
+
+.. contents::
+
+
+Class ``H5pyFormatter``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: H5pyFormatter
+   :members:

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -19,6 +19,7 @@ To use on of the following packages in your code, you must import them explicitl
    dropbox
    git
    glite
+   hdf5
    htcondor
    keras
    lsf

--- a/law/contrib/hdf5/__init__.py
+++ b/law/contrib/hdf5/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+"""
+HDF5 contrib functionality.
+"""
+
+
+__all__ = ["H5pyFormatter"]
+
+
+# provisioning imports
+from law.contrib.hdf5.formatter import H5pyFormatter

--- a/law/contrib/hdf5/formatter.py
+++ b/law/contrib/hdf5/formatter.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+HDF5 target formatters.
+"""
+
+from law.target.formatter import Formatter
+from law.target.file import get_path
+
+
+class H5pyFormatter(Formatter):
+
+    name = "h5py"
+
+    @classmethod
+    def accepts(cls, path):
+        path = get_path(path)
+        return path.endswith(".hdf5") or path.endswith(".h5")
+
+    @classmethod
+    def load(cls, path, *args, **kwargs):
+        import h5py
+
+        return h5py.File(get_path(path), 'r', *args, **kwargs)
+
+    @classmethod
+    def dump(cls, path, *args, **kwargs):
+        import h5py
+
+        return h5py.File(get_path(path), 'w', *args, **kwargs)

--- a/law/contrib/hdf5/formatter.py
+++ b/law/contrib/hdf5/formatter.py
@@ -4,6 +4,7 @@
 HDF5 target formatters.
 """
 
+
 from law.target.formatter import Formatter
 from law.target.file import get_path
 
@@ -21,10 +22,10 @@ class H5pyFormatter(Formatter):
     def load(cls, path, *args, **kwargs):
         import h5py
 
-        return h5py.File(get_path(path), 'r', *args, **kwargs)
+        return h5py.File(get_path(path), "r", *args, **kwargs)
 
     @classmethod
     def dump(cls, path, *args, **kwargs):
         import h5py
 
-        return h5py.File(get_path(path), 'w', *args, **kwargs)
+        return h5py.File(get_path(path), "w", *args, **kwargs)


### PR DESCRIPTION
This adds a HDF5 Formatter using [`h5py`](https://github.com/h5py/h5py).

I added this functionality to `law.contrib.hdf5` instead of `law.contrib.h5py` in order to make it easy to add support for HDF5 using [`pytable`](https://github.com/PyTables/PyTables) in the future.