### PR TITLE
Refactor Slack notifications to be asynchronous and pretty

### DIFF
--- a/law/contrib/slack/parameter.py
+++ b/law/contrib/slack/parameter.py
@@ -32,9 +32,9 @@ class NotifySlackParameter(NotifyParameter):
         cfg = Config.instance()
 
         if not token:
-            token = cfg.get("notifications", "slack_token")
+            token = cfg.get_expanded("notifications", "slack_token")
         if not channel:
-            channel = cfg.get("notifications", "slack_channel")
+            channel = cfg.get_expanded("notifications", "slack_channel")
 
         if token and channel:
             parts = dict(parts)

--- a/law/contrib/slack/parameter.py
+++ b/law/contrib/slack/parameter.py
@@ -5,10 +5,9 @@ Slack notification.
 """
 
 
-import logging
 import os
-import traceback
 import threading
+import logging
 
 from law.config import Config
 from law.parameter import NotifyParameter
@@ -29,7 +28,6 @@ class NotifySlackParameter(NotifyParameter):
     @staticmethod
     def notify(success, title, parts, token=None, channel=None, **kwargs):
         import slackclient
-        import json
 
         cfg = Config.instance()
 
@@ -63,6 +61,9 @@ class NotifySlackParameter(NotifyParameter):
                 })
 
             def notify_thread(token, request):
+                import json
+                import traceback
+
                 try:
                     # token might be a file
                     if os.path.isfile(token):

--- a/law/contrib/slack/parameter.py
+++ b/law/contrib/slack/parameter.py
@@ -37,13 +37,8 @@ class NotifySlackParameter(NotifyParameter):
             channel = cfg.get_expanded("notifications", "slack_channel")
 
         if token and channel:
-            parts = dict(parts)
-
-            if "Task" in parts:
-                text = "*Notification from: {}!*".format(parts["Task"])
-                del parts["Task"]
-            else:
-                text = "# New Notification!"
+            text = "*Notification from: {}!*".format(parts["Task"])
+            del parts["Task"]
 
             attachment = {
                 "color": "#4BB543" if success else "#FF0033",

--- a/law/decorator.py
+++ b/law/decorator.py
@@ -238,4 +238,5 @@ def notify(fn, opts, task, *args, **kwargs):
             try:
                 fn(success, title, parts if raw else message, **opts)
             except Exception as e:
-                logger.warning("notification failed via transport '{}': {}".format(fn, e))
+                t = traceback.format_exc()
+                logger.warning("notification failed via transport '{}': {}\n{}".format(fn, e, t))

--- a/law/decorator.py
+++ b/law/decorator.py
@@ -29,6 +29,7 @@ import traceback
 import functools
 import random
 import socket
+import collections
 import logging
 
 import luigi
@@ -221,15 +222,15 @@ def notify(fn, opts, task, *args, **kwargs):
         duration = human_time_diff(seconds=round(time.time() - t0, 1))
         status_string = "succeeded" if success else "failed"
         title = "Task {} {}!".format(_task.get_task_family(), status_string)
-        parts = [
+        parts = collections.OrderedDict([
             ("Host", socket.gethostname()),
             ("Duration", duration),
             ("Last message", "-" if not len(_task._message_cache) else _task._message_cache[-1]),
             ("Task", str(_task)),
-        ]
+        ])
         if not success:
-            parts.append(("Traceback", traceback.format_exc()))
-        message = "\n".join("{}: {}".format(*tpl) for tpl in parts)
+            parts["Traceback"] = traceback.format_exc()
+        message = "\n".join("{}: {}".format(*tpl) for tpl in parts.items())
 
         # dispatch via all transports
         for transport in transports:

--- a/law/parameter.py
+++ b/law/parameter.py
@@ -114,7 +114,7 @@ class NotifyParameter(luigi.BoolParameter):
     with the :py:func:`law.notify` function, *notification_func* is called with at least three
     arguments: *success*, *title* and *message*. *success* is a boolean which is *True* when the
     decorated function did not raise an exception. *title* is always a string. When *raw* is *False*
-    (the default), *message* is also a string. Otherwise, it is a list of tuples containing key
+    (the default), *message* is also a string. Otherwise, it is an ordered dictionary containing key
     value pairs describing the message content. All options passed to
     :py:func:`law.decorator.notify` are forwarded to *notification_func* as optional arguments.
     """


### PR DESCRIPTION
* The Slack API call is now started as a thread, such that is does not block task execution.
* The notification style is improved by utilising the attachment function of the Slack API.