### PR TITLE
Fix local copy if path doesn't exist

### DIFF
--- a/law/target/local.py
+++ b/law/target/local.py
@@ -148,7 +148,7 @@ class LocalFileSystem(FileSystem):
         dst = self._unscheme(dst)
 
         # dst might be an existing directory
-        if self.isdir(dst):
+        if self.exists(dst) and self.isdir(dst):
             dst = os.path.join(dst, os.path.basename(src))
         else:
             # create missing dirs

--- a/law/target/local.py
+++ b/law/target/local.py
@@ -143,25 +143,7 @@ class LocalFileSystem(FileSystem):
 
         return elems
 
-    def copy(self, src, dst, dir_perm=None, **kwargs):
-        src = self._unscheme(src)
-        dst = self._unscheme(dst)
-
-        # dst might be an existing directory
-        if self.exists(dst) and self.isdir(dst):
-            dst = os.path.join(dst, os.path.basename(src))
-        else:
-            # create missing dirs
-            dst_dir = self.dirname(dst)
-            if dst_dir and not self.exists(dst_dir):
-                self.mkdir(dst_dir, dir_perm=dir_perm, recursive=True)
-
-        # copy the file
-        shutil.copy2(src, dst)
-
-        return dst
-
-    def move(self, src, dst, dir_perm=None, **kwargs):
+    def _prepare_paths(self, src, dst, dir_perm=None):
         src = self._unscheme(src)
         dst = self._unscheme(dst)
 
@@ -175,7 +157,18 @@ class LocalFileSystem(FileSystem):
             if dst_dir and not self.exists(dst_dir):
                 self.mkdir(dst_dir, dir_perm=dir_perm, recursive=True)
 
-        # simply move
+        return src, dst
+
+    def copy(self, src, dst, dir_perm=None, **kwargs):
+        src, dst = self._prepare_paths(src, dst, dir_perm=dir_perm)
+
+        shutil.copy2(src, dst)
+
+        return dst
+
+    def move(self, src, dst, dir_perm=None, **kwargs):
+        src, dst = self._prepare_paths(src, dst, dir_perm=dir_perm)
+
         shutil.move(src, dst)
 
         return dst


### PR DESCRIPTION
[`LocalFileSystem::isdir(dst)`](https://github.com/riga/law/blob/master/law/target/local.py#L151) will fail if `dst` doesn't exists.
Noticed while using `my_local_target.localize('r', is_tmp=True)`.

The second commit unifies directory preparation of `.copy()` and `.move()` to reduce code duplication.