### PR TITLE
Continue scanning and pruning the whole waiting list list when submitting

### DIFF
--- a/law/workflow/remote.py
+++ b/law/workflow/remote.py
@@ -429,15 +429,17 @@ class BaseRemoteWorkflowProxy(BaseWorkflowProxy):
         n_parallel = sys.maxsize if task.parallel_jobs < 0 else task.parallel_jobs
         new_jobs = OrderedDict()
         for job_num, branches in list(self.submission_data.waiting_jobs.items()):
-            if n_active + len(new_jobs) >= n_parallel:
-                break
-
-            # remove job from the waiting list
-            del self.submission_data.waiting_jobs[job_num]
-
             if skip_job(job_num, branches):
+                # remove jobs that don't need to be submitted
+                del self.submission_data.waiting_jobs[job_num]
                 continue
 
+            # stop for now when n_parllel jobs are already running
+            if n_active + len(new_jobs) >= n_parallel:
+                continue
+
+            # remove jobs that are going to be submitted from the waiting list
+            del self.submission_data.waiting_jobs[job_num]
             new_jobs[job_num] = sorted(branches)
 
         # add new jobs to the jobs to submit, maybe also shuffle


### PR DESCRIPTION
Currently the loop over the waiting jobs in the `submit` function of the `BaseRemoteWorkflowProxy` breaks when `n_parallel` jobs are reached. This is fine for the sole purpose of determining which tasks need to be submitted.

However, if the waiting list contains multiple sequences of unfinished and already finished jobs it will break during an sequence of unfinished jobs, when `n_parallel` is exceeded, and leave the remaining already finished jobs in a later section of the waiting list uncounted. This results in the finished jobs count being lower that it actually is in the polling. The missing finished jobs will eventually be included without being resubmitted, so this is a purely cosmetical, albeit very confusing issue.

The proposed solution keeps scanning the waiting list for the sole purpose of removing already finished jobs that occur later in the list.