### PR TITLE
Add Suspended Status to HTCondorJobManager

### DIFF
--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -245,7 +245,7 @@ class HTCondorJobManager(BaseJobManager):
     @classmethod
     def map_status(cls, status_flag):
         # see http://pages.cs.wisc.edu/~adesmet/status.html
-        if status_flag in ("0", "1", "U", "I"):
+        if status_flag in ("0", "1", "7", "U", "I"):
             return cls.PENDING
         elif status_flag in ("2", "R"):
             return cls.RUNNING


### PR DESCRIPTION
If a job is suspended, it will get the "JobStatus == 7" flag. Up to now the status was mapped to `cls.FAILED` and consequently resubmitted. But the job is running again after some time, which leads to multiple submissions of the same job (in the worst case). This change treats the status suspended as `cls.PENDING` instead of `cls.FAILED` in order to avoid resubmission. 
It seems that the suspended status "7" is not an official status from http://pages.cs.wisc.edu/~adesmet/status.html, but definitely present at e.g. RWTH htcondor. Therefore it does not interfere with the "standard" htcondor batch systems.