### PR TITLE
[contrib/git] Fix bundling of git submodules.

### DIFF
--- a/law/contrib/git/__init__.py
+++ b/law/contrib/git/__init__.py
@@ -65,11 +65,14 @@ class BundleGitRepository(Task):
             self.bundle(tmp.path)
 
     def bundle(self, dst_path):
-        bundle_script = rel_path(__file__, "scripts", "bundle_repository.sh")
-        cmd = [bundle_script, self.get_repo_path(), get_path(dst_path)]
-        cmd += [" ".join(self.exclude_files)]
-        cmd += [" ".join(self.include_files)]
+        cmd = "{} \"{}\" \"{}\" \"{}\" \"{}\"".format(
+            rel_path(__file__, "scripts", "bundle_repository.sh"),
+            self.get_repo_path(),
+            get_path(dst_path),
+            " ".join(self.exclude_files),
+            " ".join(self.include_files),
+        )
 
-        code = interruptable_popen(cmd, executable="/bin/bash")[0]
+        code = interruptable_popen(cmd, shell=True, executable="/bin/bash")[0]
         if code != 0:
             raise Exception("repository bundling failed")

--- a/law/contrib/git/__init__.py
+++ b/law/contrib/git/__init__.py
@@ -70,6 +70,6 @@ class BundleGitRepository(Task):
         cmd += [" ".join(self.exclude_files)]
         cmd += [" ".join(self.include_files)]
 
-        code = interruptable_popen(cmd)[0]
+        code = interruptable_popen(cmd, executable="/bin/bash")[0]
         if code != 0:
             raise Exception("repository bundling failed")

--- a/law/contrib/git/scripts/bundle_repository.sh
+++ b/law/contrib/git/scripts/bundle_repository.sh
@@ -55,6 +55,8 @@ action() {
         sgit commit -m "[tmp] Add all changes." > /dev/null && \
         sgit archive --prefix="$repo_name/" --format=tar -o "$tmp_arc" HEAD && \
         sgit submodule foreach --recursive --quiet "\
+            sgit add -f . &> /dev/null && \
+            sgit commit -m \"[tmp] Add all changes.\" > /dev/null && \
             sgit archive --prefix=\"$repo_name/\$path/\" --format=tar --output=\"$rnd_\$sha1.tar\" HEAD && \
             tar --concatenate --file=\"$tmp_arc\" \"$rnd_\$sha1.tar\" \
             && rm \"$rnd_\$sha1.tar\"" && \

--- a/law/contrib/git/scripts/bundle_repository.sh
+++ b/law/contrib/git/scripts/bundle_repository.sh
@@ -43,8 +43,6 @@ action() {
     local repo_name="$( basename "$repo_path" )"
     local tmp_dir="$( mktemp -d )"
     local tmp_list="$( mktemp -u "$tmp_dir/tmp.XXXXXXXXXX" ).txt"
-    local tmp_arc="$( mktemp -u "$tmp_dir/tmp.XXXXXXXXXX" ).tar"
-    local rnd="$RANDOM$RANDOM"
 
     # on nfs systems the .git/index.lock might be re-appear due to sync issues
     sgit() {

--- a/law/contrib/git/scripts/bundle_repository.sh
+++ b/law/contrib/git/scripts/bundle_repository.sh
@@ -60,21 +60,17 @@ action() {
         cd "$tmp_dir/$repo_name" && \
         rm -rf $ignore_files && \
         sgit add -A . &> /dev/null && \
-        sgit add -f $include_files &> /dev/null; \
+        [ ! -z "$$include_files" ] && sgit add -f $include_files &> /dev/null; \
         sgit commit -m "$commit_msg" &> /dev/null; \
+        for elem in $( sgit ls-files ); do echo "$repo_name/$elem" >> "$tmp_list"; done && \
         sgit submodule foreach --recursive --quiet "\
             git add -A . &> /dev/null && \
-            git commit -m \"$commit_msg\" &> /dev/null || true" && \
-        sgit ls-files --recurse-submodules > "$tmp_list" && \
+            git commit -m \"$commit_msg\" &> /dev/null; \
+            for elem in \$( git ls-files ); do echo \"$repo_name/\$path/\$elem\" >> \"$tmp_list\"; done" && \
         mkdir -p "$( dirname "$dst_path" )" && \
-        cd .. && \
-        ( \
-            for f in $( cat "$tmp_list"); do \
-                [ ! -z "$( echo "$f" | xargs )" ] && echo "$repo_name/$f"; \
-            done
-        ) | tar -czf "$dst_path" -T -
+        cd "$tmp_dir" && \
+        tar -czf "$dst_path" -T "$tmp_list"
     )
-
     local ret="$?"
 
     rm -rf "$tmp_dir"

--- a/law/contrib/mercurial/__init__.py
+++ b/law/contrib/mercurial/__init__.py
@@ -70,6 +70,6 @@ class BundleMercurialRepository(Task):
         cmd += [" ".join(self.exclude_files)]
         cmd += [" ".join(self.include_files)]
 
-        code = interruptable_popen(cmd)[0]
+        code = interruptable_popen(cmd, executable="/bin/bash")[0]
         if code != 0:
             raise Exception("repository bundling failed")

--- a/law/contrib/mercurial/scripts/bundle_repository.sh
+++ b/law/contrib/mercurial/scripts/bundle_repository.sh
@@ -8,6 +8,7 @@
 # 2. the path where the bundle should be stored, should end with .tgz
 # 3. (optional) space-separated list of files or directories to ignore, supports globbing
 # 4. (optional) space-separated list of files or directories to force-add, supports globbing
+# 5. (optional) commit message, defaults to "[tmp] Commit before bundling."
 
 action() {
     # handle arguments
@@ -33,15 +34,20 @@ action() {
         return "4"
     fi
 
+    local ignore_files="$3"
+    local include_files="$4"
+    local commit_msg="$5"
+    [ -z "$commit_msg" ] && commit_msg="[tmp] Commit before bundling."
+
     local tmp_dir="$( mktemp -d )"
 
     ( \
         cp -R "$repo_path" "$tmp_dir/" && \
         cd "$tmp_dir/$( basename "$repo_path" )" && \
-        rm -rf $3 && \
+        rm -rf $ignore_files && \
         hg add &> /dev/null && \
-        hg add $4 &> /dev/null; \
-        hg commit -m "[tmp] Add all changes." > /dev/null; \
+        hg add $include_files &> /dev/null; \
+        hg commit -m "$commit_msg" > /dev/null; \
         hg archive --prefix="$( basename "$repo_path" )/" --type tgz "$dst_path" \
     )
     local ret="$?"


### PR DESCRIPTION
The bundling of submodules did not take into account changes and was using git features that might not exist on versions older than 3 years. The bundling strategy now uses `git ls-files` followed by a simple `tar -cz` instead of `git archive`.

This fixes #72.