### PR TITLE
Singularity sandboxes without bind access

### DIFF
--- a/law/config.py
+++ b/law/config.py
@@ -122,7 +122,7 @@ class Config(ConfigParser):
             "stagein_dir": "stagein",
             "stageout_dir": "stageout",
             "allow_binds": True,
-            "forward_env": True,
+            "forward_law": True,
         },
         "singularity_sandbox_env": {},
         "singularity_sandbox_volumes": {},

--- a/law/config.py
+++ b/law/config.py
@@ -121,6 +121,8 @@ class Config(ConfigParser):
             "bin_dir": "bin",
             "stagein_dir": "stagein",
             "stageout_dir": "stageout",
+            "allow_binds": True,
+            "forward_env": True,
         },
         "singularity_sandbox_env": {},
         "singularity_sandbox_volumes": {},

--- a/law/contrib/singularity/sandbox.py
+++ b/law/contrib/singularity/sandbox.py
@@ -178,9 +178,10 @@ class SingularitySandbox(Sandbox):
                         env["LUIGI_CONFIG_PATH"] = p
                     break
 
-        if (self.stagein_info or self.stageout_info) and not self.allow_binds:
-            raise Exception("Cannot use stage-in or -out if binds are not allowed.")
         # add staging directories
+        if (self.stagein_info or self.stageout_info) and not allow_binds:
+            raise Exception("cannot use stage-in or -out if binds are not allowed")
+
         if self.stagein_info:
             env["LAW_SANDBOX_STAGEIN_DIR"] = dst(stagein_dir)
             mount(self.stagein_info.stage_dir.path, dst(stagein_dir))
@@ -190,8 +191,8 @@ class SingularitySandbox(Sandbox):
 
         # forward volumes defined in the config and by the task
         vols = self._get_volumes()
-        if vols and not self.allow_binds:
-            raise Exception("Cannot forward volumes to Sandbox if binds are not allowed.")
+        if vols and not allow_binds:
+            raise Exception("cannot forward volumes to sandbox if binds are not allowed")
 
         for hdir, cdir in six.iteritems(vols):
             if not cdir:

--- a/law/contrib/singularity/sandbox.py
+++ b/law/contrib/singularity/sandbox.py
@@ -30,12 +30,6 @@ class SingularitySandbox(Sandbox):
     # env cache per image
     _envs = {}
 
-    def __init__(self, *args, **kwargs):
-        super(SingularitySandbox, self).__init__(*args, **kwargs)
-
-        self.cfg = Config.instance()
-        self.cfg_section = self.get_config_section()
-
     @property
     def image(self):
         return self.name

--- a/law/contrib/singularity/sandbox.py
+++ b/law/contrib/singularity/sandbox.py
@@ -140,12 +140,12 @@ class SingularitySandbox(Sandbox):
         else:
             allow_binds = self.cfg.get_expanded(self.cfg_section, "allow_binds")
 
-        # determine whether environment forwarding is allowed
-        forward_env_cb = getattr(self.task, "singularity_forward_env", None)
-        if callable(forward_env_cb):
-            forward_env = forward_env_cb()
+        # determine whether law software forwarding is allowed
+        forward_law_cb = getattr(self.task, "singularity_forward_law", None)
+        if callable(forward_law_cb):
+            forward_law = forward_law_cb()
         else:
-            forward_env = self.cfg.get_expanded(self.cfg_section, "forward_env")
+            forward_law = self.cfg.get_expanded(self.cfg_section, "forward_law")
 
         # environment variables to set
         env = self._get_env()
@@ -153,7 +153,7 @@ class SingularitySandbox(Sandbox):
         # prevent python from writing byte code files
         env["PYTHONDONTWRITEBYTECODE"] = "1"
 
-        if forward_env:
+        if forward_law:
             # adjust path variables
             if allow_binds:
                 env["PATH"] = os.pathsep.join(["$PATH", dst("bin")])

--- a/law/contrib/singularity/sandbox.py
+++ b/law/contrib/singularity/sandbox.py
@@ -232,7 +232,7 @@ class SingularitySandbox(Sandbox):
         # handle scheduling within the container
         ls_flag = "--local-scheduler"
         if self.force_local_scheduler() and ls_flag not in proxy_cmd:
-            proxy_cmd.append(ls_flag)
+            proxy_cmd.extend([ls_flag, "True"])
 
         # build the final command
         cmd = quote_cmd(["singularity", "exec"] + args + [self.image, "bash", "-l", "-c",


### PR DESCRIPTION
This PR adds the option to run singularity sandboxes without bind access and/or without forwarding the law environment.

Some singularity instances disallow user bind control, which clashes with the current directory forwarding.
For the base law environment (law & dependencies, config, cli), one could instead point to the paths on the host system (if they are accessible from within the container). This would mean that the PYTHONPATH includes the entire site/dist-packages directory instead of only the law dependencies. The required packages could also be copied to a tmp directory on the host system to prevent this.

As an alternative, one could not forward the base environment and set up an independent environment in the sandbox, e.g. using sandbox_setup_cmds(). I think this also makes sense as an option independent of whether bind access is possible (and could be added to the docker sandbox as well).