### PR TITLE
Fix autocompletion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@
    :alt: License
 
 
-**Note**: This project is currently under development. Version 0.1.0 will be the first, fully documented beta release, targetted for February 2020.
+**Note**: This project is currently under development. Version 0.1.0 will be the first, fully documented beta release, targetted for early 2020.
 
 Use law to build complex and large-scale task workflows. It is build on top of `luigi <https://github.com/spotify/luigi>`__ and adds abstractions for **run locations**, **storage locations** and **software environments**. Law strictly disentangles these building blocks and ensures they remain interchangeable and resource-opportunistic.
 

--- a/law/cli/completion.sh
+++ b/law/cli/completion.sh
@@ -40,85 +40,95 @@ _law_complete() {
 
     # complete the "run" subcommand
     if [ "$sub_cmd" = "run" ]; then
+        # no completion when no index file is found
         if [ ! -f "$index_file" ]; then
             COMPREPLY=()
             return
         fi
 
-        # task family
+        # complete the task family
         if [ "$COMP_CWORD" = "2" ]; then
             COMPREPLY=( $( compgen -W "$( _law_grep_Po "[^\:]+\:\K(.+)(?=\:.+)" "$index_file" )" -- "$cur" ) )
             return
         fi
         local task_family="${COMP_WORDS[2]}"
 
-        # parameters of the root task
+        # complete parameters of the root task
+        # and if parameters were found, stop
         local inp="${cur##-}"
         inp="${inp##-}"
         COMPREPLY=( $( compgen -W "$( _law_grep_Po "[^\:]+\:$task_family\:\K.+" "$index_file" ) $common_run_params" -P "--" -- "$inp" ) )
+        if [ "${#COMPREPLY[@]}" != "0" ]; then
+            return
+        fi
 
-        if [ "${#COMPREPLY[@]}" = "0" ] && [ "${cur:0:2}" = "--" ]; then
-            local tasks=( $( _law_grep_Po "[^\:]+\:\K$inp[^\:]*(?=\:.+)" "$index_file" ) )
+        # when no root task parameters were found, try to complete task-level parameters,
+        # but only when the current input starts with two "-"
+        if [ "${cur:0:2}" = "--" ]; then
+            local namespace="$( echo "$inp" | _law_grep_Po "^.*\.(?=[^\.]*$)" )"
+            local class_and_param="$( echo "$inp" | _law_grep_Po "\.?\K[^\.]*$" )"
+            local class="$( echo "$class_and_param" | _law_grep_Po "^[^-]+" )"
+            local param="$( echo "$class_and_param" | _law_grep_Po "^[^-]+-\K.*" )"
+            local family="$namespace$class"
 
-            if [[ "$( echo $inp | _law_grep_Po "\K[^\.]+$" )" != *"-"* ]] && [ "${#tasks[@]}" -gt "1" ]; then
-                # other task families
-                COMPREPLY=( $( compgen -W "$( echo ${tasks[@]} )" -P "--" -S "-" -- "$inp" ) )
-            else
-                # parameters of other tasks
-                local task="$( echo $inp | _law_grep_Po "^[^-]*" )"
-                local curparam="$( echo $inp | _law_grep_Po "^[^-]*-\K.*" )"
+            # find tasks that match the family
+            local tasks=( $( _law_grep_Po "[^\:]+\:\K$family[^\:]*(?=\:.+)" "$index_file" ) )
+            if [ "${#tasks[@]}" != "0" ]; then
+                # complete the task family when there is more than one match and
+                # when there is not yet a "-" after the task class name
+                if [ "${#tasks[@]}" -gt "1" ] && [[ "$class_and_param" != *"-"* ]]; then
+                    # complete the task family
+                    COMPREPLY=( $( compgen -W "$( echo ${tasks[@]} )" -P "--" -S "-" -- "$inp" ) )
+                else
+                    # complete parameters, including the matching task family
+                    # when there is only one matching task, overwrite the family
+                    [ "${#tasks[@]}" = "1" ] && family="${tasks[0]}"
 
-                [[ "$( echo $inp | _law_grep_Po "\K[^\.]+$" )" != *"-"* ]] && task="${tasks[0]}"
-                [ "$( echo ${task:${#task}-1} )" == "-" ] && task="${task:0:${#task}-1}"
+                    # get all parameters and do a simple comparison
+                    local all_params=( $( _law_grep_Po "[^\:]\:$family\:\K.*" "$index_file" ) )
+                    local words=()
+                    for p in "${all_params[@]}"; do
+                        if [ -z "$param" ] || [ ! -z "$( echo "$p" | _law_grep_Po "^$param" )" ]; then
+                            words+=("$family-$p")
+                        fi
+                    done
+                    unset param
 
-                local params=( $( _law_grep_Po "[^\:]\:$task\:\K.*" "$index_file" ) )
-                local words=()
-                for param in "${params[@]}"; do
-                    if [ -z "$curparam" ] || [ ! -z "$( echo "$param" | _law_grep_Po "^$curparam" )" ]; then
-                        words+=("$task-$param")
-                    fi
-                done
-                unset param
-
-                COMPREPLY=( $( compgen -W "$( echo ${words[@]} )" -P "--" -- "$inp" ) )
+                    COMPREPLY=( $( compgen -W "$( echo ${words[@]} )" -P "--" -- "$inp" ) )
+                fi
             fi
         fi
-    fi
 
     # complete the "index" subcommand
-    if [ "$sub_cmd" = "index" ]; then
+    elif [ "$sub_cmd" = "index" ]; then
         local words="modules no-externals remove location verbose help"
         local inp="${cur##-}"
         inp="${inp##-}"
         COMPREPLY=( $( compgen -W "$( echo $words )" -P "--" -- "$inp" ) )
-    fi
 
     # complete the "software" subcommand
-    if [ "$sub_cmd" = "software" ]; then
+    elif [ "$sub_cmd" = "software" ]; then
         local words="location remove help"
         local inp="${cur##-}"
         inp="${inp##-}"
         COMPREPLY=( $( compgen -W "$( echo $words )" -P "--" -- "$inp" ) )
-    fi
 
     # complete the "config" subcommand
-    if [ "$sub_cmd" = "config" ]; then
+    elif [ "$sub_cmd" = "config" ]; then
         local words="remove expand location help"
         local inp="${cur##-}"
         inp="${inp##-}"
         COMPREPLY=( $( compgen -W "$( echo $words )" -P "--" -- "$inp" ) )
-    fi
 
     # complete the "completion" subcommand
-    if [ "$sub_cmd" = "completion" ]; then
+    elif [ "$sub_cmd" = "completion" ]; then
         local words="help"
         local inp="${cur##-}"
         inp="${inp##-}"
         COMPREPLY=( $( compgen -W "$( echo $words )" -P "--" -- "$inp" ) )
-    fi
 
     # complete the "location" subcommand
-    if [ "$sub_cmd" = "location" ]; then
+    elif [ "$sub_cmd" = "location" ]; then
         local words="help"
         local inp="${cur##-}"
         inp="${inp##-}"

--- a/law/cli/index.py
+++ b/law/cli/index.py
@@ -169,7 +169,7 @@ def execute(args):
             # fill stats
             if cls.__module__ not in stats:
                 stats[cls.__module__] = []
-            stats[cls.__module__].append((cls.task_family, params))
+            stats[cls.__module__].append((cls.get_task_family(), params))
 
             f.write(index_line(cls, params) + "\n")
 

--- a/law/cli/index.py
+++ b/law/cli/index.py
@@ -122,8 +122,8 @@ def execute(args):
         # automatically map it to "_", i.e., it will fail to lookup the actual task class
         # skip the task
         if "-" in task_family:
-            logger.critical("skipping task '{}' as the its family '{}' contains a '-' which cannot "
-                "be interpreted by luigi's command line parser, please use '_' or alike".format(
+            logger.critical("skipping task '{}' as its family '{}' contains a '-' which cannot be "
+                "interpreted by luigi's command line parser, please use '_' or alike".format(
                     cls, task_family))
             continue
 
@@ -132,9 +132,9 @@ def execute(args):
         # is not able to decide whether it should complete the task family or a task-level parameter
         # skip the task
         if "_" in task_family.rsplit(".", 1)[-1]:
-            logger.error("skipping task '{}' as the its family '{}' contains a '_' after the "
-                "namespace definition which would lead to ambiguities between task families and "
-                "task-level parameters in the law shell autocompletion".format(cls, task_family))
+            logger.error("skipping task '{}' as its family '{}' contains a '_' after the namespace "
+                "definition which would lead to ambiguities between task families and task-level "
+                "parameters in the law shell autocompletion".format(cls, task_family))
             continue
 
         task_classes.append(cls)
@@ -151,9 +151,7 @@ def execute(args):
 
     def index_line(cls, params):
         # format: "module_id:task_family:param param ..."
-        # replace "_" with "-" to be in line with luigi's argument parsing
-        task_family = cls.get_task_family().replace("_", "-")
-        return "{}:{}:{}".format(cls.__module__, task_family, " ".join(params))
+        return "{}:{}:{}".format(cls.__module__, cls.get_task_family(), " ".join(params))
 
     stats = OrderedDict()
 

--- a/law/cli/run.py
+++ b/law/cli/run.py
@@ -49,7 +49,7 @@ def execute(args):
                 task_cls = getattr(mod, cls_name)
                 if not issubclass(task_cls, Task):
                     abort("object '{}' is not a Task".format(args.task_family))
-                task_family = task_cls.task_family
+                task_family = task_cls.get_task_family()
         except ImportError as e:
             # keep the error in case the task family cannot be inferred from the index file
             error = e

--- a/law/contrib/cms/job.py
+++ b/law/contrib/cms/job.py
@@ -52,6 +52,9 @@ class CMSJobDashboard(BaseJobDashboard):
             e.args = (e.message,) + e.args[1:]
             raise e
 
+        # get the task family for use as default application name
+        task_family = task.get_task_family() if isinstance(task, law.Task) else task
+
         # mandatory (persistent) attributes
         self.task_id = task.task_id if isinstance(task, law.Task) else task
         self.cms_user = cms_user
@@ -62,7 +65,7 @@ class CMSJobDashboard(BaseJobDashboard):
         self.task_type = task_type
         self.site = site
         self.executable = executable
-        self.application = application or (task.task_family if isinstance(task, law.Task) else task)
+        self.application = application or task_family
         self.application_version = application_version or self.task_id.rsplit("_", 1)[1]
         self.submission_tool = submission_tool
         self.submission_type = submission_type

--- a/law/polyfills.sh
+++ b/law/polyfills.sh
@@ -9,11 +9,11 @@ action() {
 
 
     # flag that is "1" when on a Mac, empty otherwise
-    export _law_is_mac="$( [ "$( uname -s )" = "Darwin" ] && echo "1" )"
+    export _law_on_mac="$( [ "$( uname -s )" = "Darwin" ] && echo "1" || echo "0" )"
 
 
     # cross-OS grep
-    if [ "${_law_is_mac}" = "1" ]; then
+    if [ "${_law_on_mac}" = "1" ]; then
         _law_grep_path="$( which grep 2> /dev/null )"
     else
         _law_grep_path="$( which --skip-alias --skip-functions grep 2> /dev/null )"
@@ -29,7 +29,7 @@ action() {
 
 
     # cross-OS grep -Po
-    if [ "${_law_is_mac}" = "1" ]; then
+    if [ "${_law_on_mac}" = "1" ]; then
         _law_grep_Po() {
             perl -nle "print $& if m{$1}" "${@:2}"
         }

--- a/law/task/base.py
+++ b/law/task/base.py
@@ -115,7 +115,7 @@ class BaseTask(luigi.Task):
         # remove params that are preferably set via cli class arguments
         if _prefer_cli:
             cls_args = []
-            prefix = cls.task_family + "_"
+            prefix = cls.get_task_family() + "_"
             if luigi.cmdline_parser.CmdlineParser.get_instance():
                 for key in global_cmdline_values().keys():
                     if key.startswith(prefix):
@@ -334,7 +334,7 @@ class Task(BaseTask):
             cfg = Config.instance()
             color = cfg.get_expanded_boolean("task", "colored_repr")
 
-        family = self._repr_family(self.task_family, color=color)
+        family = self._repr_family(self.get_task_family(), color=color)
 
         parts = [
             self._repr_param(*pair, color=color)


### PR DESCRIPTION
This PR fixes the autocompletion in cases where the task family contains underscores. Also, when running `law index`, errors are logged in case a task family contains dashes (probably in the namespace definition), or underscores in the class name (leads to ambiguities between task families and task-level parameters, and is considered bad Python practice anyway).