### PR TITLE
Refactor job argument handling

### DIFF
--- a/law/contrib/arc/workflow.py
+++ b/law/contrib/arc/workflow.py
@@ -174,6 +174,12 @@ class ARCWorkflow(BaseRemoteWorkflow):
     arc_ce = CSVParameter(default=(), significant=False, description="target arc computing "
         "element(s), default: ()")
 
+    arc_job_kwargs = []
+    arc_job_kwargs_submit = ["arc_ce"]
+    arc_job_kwargs_cancel = None
+    arc_job_kwargs_cleanup = None
+    arc_job_kwargs_query = None
+
     exclude_params_branch = {"arc_ce"}
 
     exclude_index = True

--- a/law/contrib/glite/job.py
+++ b/law/contrib/glite/job.py
@@ -30,6 +30,7 @@ _cfg = Config.instance()
 class GLiteJobManager(BaseJobManager):
 
     # chunking settings
+    chunk_size_submit = 0
     chunk_size_cancel = _cfg.get_expanded_int("job", "glite_chunk_size_cancel")
     chunk_size_cleanup = _cfg.get_expanded_int("job", "glite_chunk_size_cleanup")
     chunk_size_query = _cfg.get_expanded_int("job", "glite_chunk_size_query")

--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -28,6 +28,7 @@ _cfg = Config.instance()
 class HTCondorJobManager(BaseJobManager):
 
     # chunking settings
+    chunk_size_submit = 0
     chunk_size_cancel = _cfg.get_expanded_int("job", "htcondor_chunk_size_cancel")
     chunk_size_query = _cfg.get_expanded_int("job", "htcondor_chunk_size_query")
 

--- a/law/contrib/lsf/job.py
+++ b/law/contrib/lsf/job.py
@@ -29,6 +29,7 @@ _cfg = Config.instance()
 class LSFJobManager(BaseJobManager):
 
     # chunking settings
+    chunk_size_submit = 0
     chunk_size_cancel = _cfg.get_expanded_int("job", "lsf_chunk_size_cancel")
     chunk_size_query = _cfg.get_expanded_int("job", "lsf_chunk_size_query")
 

--- a/law/workflow/base.py
+++ b/law/workflow/base.py
@@ -65,20 +65,20 @@ class BaseWorkflowProxy(ProxyTask):
 
     def _get_task_attribute(self, name, fallback=False):
         """
-        Return an attribute of the actual task named ``<workflow_type>_<name>``.
-        When the attribute does not exist and *fallback* is *True*, try to return the task attribute
-        simply named *name*. In any case, if a requested task attribute is eventually not found, an
+        Return an attribute of the actual task named ``<workflow_type>_<name>``. When the attribute
+        does not exist and *fallback* is *True*, try to return the task attribute simply named
+        *name*. In any case, if a requested task attribute is eventually not found, an
         AttributeError is raised.
         """
         attr = "{}_{}".format(self.workflow_type, name)
-        if not fallback:
-            return getattr(self.task, attr)
-        else:
+        if fallback:
             value = getattr(self.task, attr, no_value)
             if value != no_value:
                 return value
             else:
                 return getattr(self.task, name)
+        else:
+            return getattr(self.task, attr)
 
     def complete(self):
         """


### PR DESCRIPTION
This PR changes two aspects regarding the interaction with jobs:

1. Remote workflows had to implement their own `submit_jobs()` method, but they were all very similar. A generic method is now provided directly by the `RemoteWorkflowProxy` base class.

2. Except for submission, no (keyword) arguments were passed to methods of `JobManager` implementations such as `cancel()` and `query()`. Now, there is a way to define kwargs to pass to those methods directly on task level.