### PR TITLE
Refactor TF graph formatter for v2, rename it

### DIFF
--- a/docs/contrib/tensorflow.rst
+++ b/docs/contrib/tensorflow.rst
@@ -6,10 +6,10 @@ tensorflow
 .. contents::
 
 
-Class ``TFConstantGraphFormatter``
-----------------------------------
+Class ``TFGraphFormatter``
+--------------------------
 
-.. autoclass:: TFConstantGraphFormatter
+.. autoclass:: TFGraphFormatter
    :members:
 
 

--- a/law/contrib/tensorflow/__init__.py
+++ b/law/contrib/tensorflow/__init__.py
@@ -6,10 +6,10 @@ TensorFlow contrib functionality.
 """
 
 
-__all__ = ["TFConstantGraphFormatter", "TFKerasModelFormatter", "TFKerasWeightsFormatter"]
+__all__ = ["TFGraphFormatter", "TFKerasModelFormatter", "TFKerasWeightsFormatter"]
 
 
 # provisioning imports
 from law.contrib.tensorflow.formatter import (
-    TFConstantGraphFormatter, TFKerasModelFormatter, TFKerasWeightsFormatter,
+    TFGraphFormatter, TFKerasModelFormatter, TFKerasWeightsFormatter,
 )


### PR DESCRIPTION
This PR renames the `TFConstantGraphFormatter` to `TFGraphFormatter` and also changes its formatter name to `tf_graph`. Whether or not variables are converted to constants is an optional feature now. Also, the `dump()` method accepts polymorphic and concrete (autograph) functions now and extracts their graph.