### PR TITLE
Remove unused parameter job_ids

### DIFF
--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -219,7 +219,7 @@ class HTCondorJobManager(BaseJobManager):
                         "\n{}".format(job_id, code, err))
 
             # parse the output and update query data
-            query_data.update(self.parse_long_output(out, job_ids=missing_ids))
+            query_data.update(self.parse_long_output(out))
 
         # compare to the requested job ids and perform some checks
         for _job_id in job_ids:
@@ -237,7 +237,7 @@ class HTCondorJobManager(BaseJobManager):
         return query_data if chunking else query_data[job_id]
 
     @classmethod
-    def parse_long_output(cls, out, job_ids=None):
+    def parse_long_output(cls, out):
         # retrieve information per block mapped to the job id
         query_data = {}
         for block in out.strip().split("\n\n"):


### PR DESCRIPTION
Hi,

I wanted to look at LAW's htcondor implementation, so I cloned it and open the `htcondor/job.py` in emacs and pylint gave me a bunch of warnings. The one that I fixed here was that the parameter `job_ids` was used at no point in the `parse_long_output` method, so I removed it to avoid confusion.

The other warnings were mostly the [no-else-return](https://pheanex.github.io/pylint/) warning by pylint because of the unnecessary use of `else` after `if...return`, but I think that is a question of style, e.g. kubernetes also use this under the name *space shuttle style*.

By the way, unrelated to the PR, I was looking at LAW's htcondor implementation because I was curious how it compares to the [htcondor implementation](https://github.com/nils-braun/b2luigi/blob/main/b2luigi/batch/processes/htcondor.py) in [b2luigi](https://b2luigi.readthedocs.io/en/stable/), which is Luigi extension that had been developed by my former colleague @nils-braun at Belle II and that I started using before I even knew of LAW (and which I'm now maintaining after Nils left the collaboration). I was asked by other members whether it wouldn't make sense to try to avoid duplicating efforts like e.g. implementing different batch systems, though I'm not sure how easy that would be, since the designs of the respective packages differ quite a bit and supporting a batch system isn't actually that difficult as long as it has a well-designed interface. Sadly I'm at the end of my PhD and currently lacking the time doing a major re-write of our package, but in general I'm always open to discussion, which however can happened outside this PR.

Cheers,
Michael Eliachevitch