### PR TITLE
switch so safe loading of yaml files

### DIFF
--- a/law/target/formatter.py
+++ b/law/target/formatter.py
@@ -179,7 +179,7 @@ class YAMLFormatter(Formatter):
         import yaml
 
         with open(get_path(path), "r") as f:
-            return yaml.load(f, *args, **kwargs)
+            return yaml.safe_load(f, *args, **kwargs)
 
     @classmethod
     def dump(cls, path, obj, *args, **kwargs):


### PR DESCRIPTION
switching from `load` to `safe_load` avoids this warning to be printed, and the possibility of unsafe behavior:

```
 YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read
 https://msg.pyyaml.org/load for full details.
 ```