### PR TITLE
[rich] allow passing through kwargs to RichHandler

### DIFF
--- a/law/contrib/rich/logger.py
+++ b/law/contrib/rich/logger.py
@@ -16,10 +16,11 @@ from law.util import make_list, multi_match
 
 
 def replace_console_handlers(loggers=("luigi", "luigi.*", "luigi-*", "law", "law.*"), level=None,
-        force_add=False, check_fn=None):
+        force_add=False, check_fn=None, **handler_kwargs):
     """
     Removes all tty stream handlers (i.e. those logging to *stdout* or *stderr*) from certain
-    *loggers* and adds a ``rich.logging.RichHandler`` with a specified *level*. *loggers* can either
+    *loggers* and adds a ``rich.logging.RichHandler`` with a specified *level*. Additional options
+    can be passed to the ``rich.logging.RichHandler`` via **handler_kwargs*. *loggers* can either
     be logger instances or names. In the latter case, the names are used as patterns to identify
     matching loggers. Unless *force_add* is *True*, no new handler is added when no tty stream
     handler was previously registered.
@@ -72,7 +73,7 @@ def replace_console_handlers(loggers=("luigi", "luigi.*", "luigi-*", "law", "law
                 level = logging.INFO
 
             # add the rich handler
-            logger.addHandler(rich_logging.RichHandler(level))
+            logger.addHandler(rich_logging.RichHandler(level, **handler_kwargs))
 
         # add the removed handlers to the returned list
         if removed_handlers:


### PR DESCRIPTION
Hi @riga,

this PR allows to pass kwargs down to the RichHandler.
This is useful to e.g. disable time in logging by adding `show_time=False`.
By default this is set to `True` and creates a rather ugly indentation:
![image](https://user-images.githubusercontent.com/18463582/142185712-03a6e9f6-4876-4f3c-b8b1-0ad1efb9360b.png)
However there are also other useful options, such as `rich_tracebacks`, which can be passed then to the RichHandler:

Example usage:
```python
import law

law.contrib.load("rich")
law.rich.replace_console_handlers(show_time=False, rich_tracebacks=True)
```

Best, Peter