### PR TITLE
[rich] set colored_[repr/str] options in config to False

### DIFF
--- a/law/contrib/rich/logger.py
+++ b/law/contrib/rich/logger.py
@@ -11,6 +11,7 @@ import logging
 
 import six
 
+from law.config import Config
 from law.logger import is_tty_handler
 from law.util import make_list, multi_match
 
@@ -77,5 +78,9 @@ def replace_console_handlers(loggers=("luigi", "luigi.*", "luigi-*", "law", "law
         # add the removed handlers to the returned list
         if removed_handlers:
             ret.append((logger, removed_handlers))
+        
+    # set law.cfg colored_* task settings for rich to False _always_
+    Config.instance().set("task", "colored_repr", "False")
+    Config.instance().set("task", "colored_str", "False")
 
     return ret

--- a/law/contrib/rich/logger.py
+++ b/law/contrib/rich/logger.py
@@ -74,13 +74,22 @@ def replace_console_handlers(loggers=("luigi", "luigi.*", "luigi-*", "law", "law
 
             # add the rich handler
             logger.addHandler(rich_logging.RichHandler(level))
+                
+            # emit warning for colored_* settings
+            for sec in ("task", "colored_repr"), ("task", "colored_str"), ("target", "colored_repr"), ("target", "colored_str"):
+                if Config.instance().get_expanded_boolean(*sec):
+                    logger.warning_once("Enabled `colored_repr` and/or `colored_str` for the `task` and/or `target` Config sections "
+                                        "might lead to malformed outputs. Consider disabling the coloring by adding the following to "
+                                        "your `law.cfg`:\n"
+                                        "[task]\n\n"
+                                        "colored_repr: False\n"
+                                        "colored_str: False\n\n"
+                                        "[target]\n\n"
+                                        "colored_repr: False\n"
+                                        "colored_str: False")
 
         # add the removed handlers to the returned list
         if removed_handlers:
             ret.append((logger, removed_handlers))
-        
-    # set law.cfg colored_* task settings for rich to False _always_
-    Config.instance().set("task", "colored_repr", "False")
-    Config.instance().set("task", "colored_str", "False")
 
     return ret


### PR DESCRIPTION
[_the following only affects logging using `contrib.rich`_]

Hi @riga,

`rich` automatically adds (rather intelligent) coloring. Currently is clashes with `law`'s own coloring in case `str(task)` or `repr(task)` is called and their coloring option is set to `True`. 
This leads to malformed output strings such as: 
```shell
...[0;49;32mGroupCoffeaProcessesWithModel[0m([1;49;34mversion[0m=prod27, [1;49;34mnotify[0m=False, [1;49;34manalysis_choice[0m=bbww_sl, [1;49;34myear[0m=2017, [1;49;34mrecipe[0m=tth,...
```

It seems that by default it only affects `str(task)` in the following output:
```shell
[pid 60651] Worker Worker(salt=809229854, workers=1, host=..., username=..., pid=60651) running <str(task)>
```
(Seems that this here is the bad boy initially: https://github.com/spotify/luigi/blob/4d0576c7c265afcb228097af79f316ba0de0242c/luigi/worker.py#L157 ...should probably be `%r` instead of `%s` for `self.task`, what do you think?) [1]
However just turning the coloring off safely prevents this malformed output always.

ps: It seems that (by default) this does not occur for the coloring setting of the `target`section, nevertheless I expect this to go wrong in the same way as for the tasks. Should these two setting be added in this PR too?

Best, Peter

[1]
```python
In [0]: class A:
   ...:     def __str__(self):
   ...:         return "str"
   ...:     def __repr__(self):
   ...:         return "repr"
   ...:

In [1]: print("%s" % A())
str

In [2]: print("%r" % A())
repr
```