### PR TITLE
[target] add optional file size information to representation

### DIFF
--- a/law.cfg.example
+++ b/law.cfg.example
@@ -196,6 +196,11 @@
 ; Type: boolean
 ; Default: False
 
+; filesize_repr
+; Description: A boolean flag that decides whether the file size is part of the representation.
+; Type: boolean
+; Default: False
+
 ; default_local_fs
 ; Description: The name of the section to lookup for getting the configuration of a
 ; "law.target.local.LocalFileSystem".

--- a/law.cfg.example
+++ b/law.cfg.example
@@ -197,7 +197,8 @@
 ; Default: False
 
 ; filesize_repr
-; Description: A boolean flag that decides whether the file size is part of the representation.
+; Description: A boolean flag that decides whether the file size is part of the representation for
+; targets inheriting from "law.FileSystemTarget".
 ; Type: boolean
 ; Default: False
 

--- a/law/config.py
+++ b/law/config.py
@@ -85,6 +85,7 @@ class Config(ConfigParser):
             "colored_repr": False,
             "colored_str": True,
             "expand_path_repr": False,
+            "filesize_repr": False,
             "default_local_fs": "local_fs",
             "tmp_dir": os.getenv("LAW_TARGET_TMP_DIR") or tempfile.gettempdir(),
             "tmp_dir_perm": 0o0770,

--- a/law/target/file.py
+++ b/law/target/file.py
@@ -21,7 +21,7 @@ import luigi.task
 
 from law.config import Config
 from law.target.base import Target
-from law.util import map_struct, create_random_string
+from law.util import map_struct, create_random_string, human_bytes
 
 
 class FileSystem(luigi.target.FileSystem):
@@ -163,6 +163,12 @@ class FileSystemTarget(Target, luigi.target.FileSystemTarget):
     def _repr_pairs(self, color=True):
         expand = Config.instance().get_expanded_boolean("target", "expand_path_repr")
         return Target._repr_pairs(self) + [("path", self.path if expand else self.unexpanded_path)]
+
+    def _repr_flags(self):
+        flags = Target._repr_flags(self)
+        if Config.instance().get_expanded_boolean("target", "filesize_repr"):
+            flags.append(human_bytes(self.stat().st_size, fmt=True))
+        return flags
 
     def _parent_args(self):
         return (), {}

--- a/law/target/local.py
+++ b/law/target/local.py
@@ -63,8 +63,9 @@ class LocalFileSystem(FileSystem):
     def stat(self, path, **kwargs):
         return os.stat(self._unscheme(path))
 
-    def exists(self, path):
-        return os.path.exists(self._unscheme(path))
+    def exists(self, path, stat=False, **kwargs):
+        exists = os.path.exists(self._unscheme(path))
+        return (self.stat(path, **kwargs) if exists else None) if stat else exists
 
     def isdir(self, path, **kwargs):
         return os.path.isdir(self._unscheme(path))


### PR DESCRIPTION
Hi @riga ,

This small PR adds the possibility to display the file size for any `FileSystemTarget`-type target class.

This looks as follows:

```python
In [1]: import law

In [2]: f = law.LocalFileTarget("MANIFEST.in")

# standard repr
In [3]: f.__repr__()
Out[3]: 'LocalFileTarget(path=/Users/peter/repos/law/MANIFEST.in)'

In [4]: law.Config.instance().set("target", "filesize_repr", "True")

# repr also including file size
In [5]: f.__repr__()
Out[5]: 'LocalFileTarget(path=/Users/peter/repos/law/MANIFEST.in, 156.0 bytes)'
```

This is not (yet) implemented for collections as this might be expensive information to collect, especially for _many_ remote targets.

Best, Peter