### PR TITLE
Use an absolute executable path in slurm workflows

### DIFF
--- a/law/contrib/slurm/job.py
+++ b/law/contrib/slurm/job.py
@@ -406,7 +406,7 @@ class SlurmJobFileFactory(BaseJobFileFactory):
 
             # add the executable
             if c.executable:
-                cmd = "." + ("" if c.executable.startswith("/") else "/") + c.executable
+                cmd = os.path.abspath(c.executable)
                 f.write("\n{}{}\n".format(cmd, args))
 
         logger.debug("created slurm job file at '{}'".format(job_file))


### PR DESCRIPTION
Absolute paths will always work if the filesystem layout is shared between the
submission machine and the worker node.  The previous implementation was
forcing everything to be a relative path and, in my testing, was only working
in a specific setting when submitting from the data folder.