### PR TITLE
Add JobInputFile to improve job input control

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -78,8 +78,9 @@ jobs:
         run: ./tests/docker.sh riga/law ./tests/coverage.sh
 
       - name: Upload report 🔝
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests
+          fail_ci_if_error: false

--- a/docs/api/job/base.rst
+++ b/docs/api/job/base.rst
@@ -20,6 +20,13 @@ Class ``BaseJobFileFactory``
    :members:
 
 
+Class ``JobInputFile``
+----------------------
+
+.. autoclass:: JobInputFile
+   :members:
+
+
 Class ``JobArguments``
 ----------------------
 

--- a/law/__init__.py
+++ b/law/__init__.py
@@ -9,7 +9,7 @@ __all__ = [
     "LocalFileSystem", "LocalTarget", "LocalFileTarget", "LocalDirectoryTarget",
     "TargetCollection", "FileCollection", "SiblingFileCollection", "NestedSiblingFileCollection",
     "Sandbox", "BashSandbox", "VenvSandbox",
-    "BaseJobManager", "BaseJobFileFactory", "JobArguments",
+    "BaseJobManager", "BaseJobFileFactory", "JobInputFile", "JobArguments",
     "NO_STR", "NO_INT", "NO_FLOAT", "is_no_param", "get_param", "TaskInstanceParameter",
     "DurationParameter", "BytesParameter", "CSVParameter", "MultiCSVParameter", "RangeParameter",
     "MultiRangeParameter", "NotifyParameter", "NotifyMultiParameter", "NotifyMailParameter",
@@ -65,7 +65,7 @@ from law.workflow.local import LocalWorkflow
 from law.sandbox.base import Sandbox, SandboxTask
 from law.sandbox.bash import BashSandbox
 from law.sandbox.venv import VenvSandbox
-from law.job.base import BaseJobManager, BaseJobFileFactory, JobArguments
+from law.job.base import BaseJobManager, BaseJobFileFactory, JobInputFile, JobArguments
 import law.job.dashboard
 import law.workflow.remote
 import law.contrib

--- a/law/contrib/arc/job.py
+++ b/law/contrib/arc/job.py
@@ -18,7 +18,6 @@ import subprocess
 
 from law.config import Config
 from law.job.base import BaseJobManager, BaseJobFileFactory, JobInputFile, DeprecatedInputFiles
-from law.target.file import get_scheme, remove_scheme
 from law.util import interruptable_popen, make_list, make_unique, quote_cmd
 from law.logger import get_logger
 

--- a/law/contrib/arc/job.py
+++ b/law/contrib/arc/job.py
@@ -355,7 +355,7 @@ class ARCJobFileFactory(BaseJobFileFactory):
             if f.is_remote:
                 f.copy = False
 
-        # ensure that the executable is an input file, remember to key to access it
+        # ensure that the executable is an input file, remember the key to access it
         if c.executable:
             executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
             if executable_keys:
@@ -428,7 +428,7 @@ class ARCJobFileFactory(BaseJobFileFactory):
         if c.executable:
             c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
-            path = os.path.join(c.dir, c.executable)
+            path = os.path.join(c.dir, os.path.basename(c.executable))
             if os.path.exists(path):
                 os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP)
 

--- a/law/contrib/arc/job.py
+++ b/law/contrib/arc/job.py
@@ -378,15 +378,22 @@ class ARCJobFileFactory(BaseJobFileFactory):
 
         abs_input_paths = {key: prepare_input(f) for key, f in c.input_files.items()}
 
-        # convert to definitive basenames
-        rel_input_paths = {
-            key: os.path.basename(abs_path)
+        # convert to basenames, relative to the submission or initial dir
+        maybe_basename = lambda path: path if c.absolute_paths else os.path.basename(path)
+        rel_input_paths_sub = {
+            key: maybe_basename(abs_path) if c.input_files[key].copy else abs_path
             for key, abs_path in abs_input_paths.items()
         }
-        c.render_variables.update(rel_input_paths)
+
+        # convert to basenames as seen by the job
+        rel_input_paths_job = {
+            key: os.path.basename(abs_path) if c.input_files[key].copy else abs_path
+            for key, abs_path in abs_input_paths.items()
+        }
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(rel_input_paths.values())
+        c.render_variables.update(rel_input_paths_job)
+        c.render_variables["input_files"] = " ".join(rel_input_paths_job.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -413,13 +420,13 @@ class ARCJobFileFactory(BaseJobFileFactory):
 
         # create arc-style input file pairs
         input_file_pairs = [
-            (rel_input_paths[key], "" if f.copy else abs_input_paths[key])
+            (os.path.basename(rel_input_paths_sub[key]), "" if f.copy else abs_input_paths[key])
             for key, f in c.input_files.items()
         ]
 
         # prepare the executable when given
         if c.executable:
-            c.executable = rel_input_paths[executable_key]
+            c.executable = rel_input_paths_sub[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):

--- a/law/contrib/arc/job.py
+++ b/law/contrib/arc/job.py
@@ -17,8 +17,8 @@ import random
 import subprocess
 
 from law.config import Config
-from law.job.base import BaseJobManager, BaseJobFileFactory, DeprecatedInputFiles
-from law.target.file import get_scheme
+from law.job.base import BaseJobManager, BaseJobFileFactory, JobInputFile, DeprecatedInputFiles
+from law.target.file import get_scheme, remove_scheme
 from law.util import interruptable_popen, make_list, make_unique, quote_cmd
 from law.logger import get_logger
 
@@ -345,19 +345,34 @@ class ARCJobFileFactory(BaseJobFileFactory):
                 if c[attr]:
                     c[attr] = self.postfix_output_file(c[attr], postfix)
 
-        # ensure that the executable is an input file
-        if c.executable and c.executable not in c.input_files.values():
-            c.input_files["executable_file"] = c.executable
-
-        # add postfixed input files to render variables
-        postfixed_input_files = {
-            name: os.path.basename(self.postfix_input_file(path, postfix))
-            for name, path in c.input_files.items()
+        # ensure that all input files are JobInputFile's
+        c.input_files = {
+            key: JobInputFile(f)
+            for key, f in c.input_files.items()
         }
-        c.render_variables.update(postfixed_input_files)
+
+        # ensure that the executable is an input file, remember to key to access it
+        if c.executable:
+            executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
+            if executable_keys:
+                executable_key = executable_keys[0]
+            else:
+                executable_key = "executable_file"
+                c.input_files[executable_key] = JobInputFile(c.executable)
+
+        # add potentially postfixed input files to render variables
+        postfixed_input_paths = {
+            key: (
+                os.path.basename(self.postfix_input_file(f.path, postfix if f.postfix else None))
+                if f.copy
+                else f.path
+            )
+            for key, f in c.input_files.items()
+        }
+        c.render_variables.update(postfixed_input_paths)
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(postfixed_input_files.values())
+        c.render_variables["input_files"] = " ".join(postfixed_input_paths.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -378,22 +393,31 @@ class ARCJobFileFactory(BaseJobFileFactory):
         job_file = self.postfix_input_file(os.path.join(c.dir, c.file_name), postfix)
 
         # prepare input files
-        def prepare_input(path):
-            # consider strings to be the base filename and use an identical source with no options
-            basename = os.path.basename(self.postfix_input_file(path, postfix))
-            if path and get_scheme(path) in ("file", None):
-                path = self.provide_input(os.path.abspath(path), postfix, c.dir, render_variables)
-                if not c.absolute_paths:
-                    path = os.path.basename(path)
-                    if path == basename:
-                        path = ""
-            return (basename, path)
+        def prepare_input(input_file):
+            # do not handle remote files but just forward information
+            path = input_file.path
+            if get_scheme(path) not in ("file", None):
+                return (os.path.basename(path), path)
+            path = remove_scheme(path)
+            # when not copied, just return the absolute, original path
+            abs_path = os.path.abspath(path)
+            if not input_file.copy:
+                return (os.path.basename(abs_path), abs_path)
+            # copy the file
+            abs_path = self.provide_input(
+                abs_path,
+                postfix if input_file.postfix else None,
+                c.dir,
+                render_variables if input_file.render else None,
+            )
+            basename = os.path.basename(abs_path)
+            return (basename, abs_path if c.absolute_paths else "")
 
-        c.input_files = {name: prepare_input(path) for name, path in c.input_files.items()}
+        prepared_input_paths = {key: prepare_input(f) for key, f in c.input_files.items()}
 
         # prepare the executable when given
         if c.executable:
-            c.executable = os.path.basename(self.postfix_input_file(c.executable, postfix))
+            c.executable = prepared_input_paths[executable_key][0]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):
@@ -424,7 +448,7 @@ class ARCJobFileFactory(BaseJobFileFactory):
         if c.job_name:
             content.append(("jobName", c.job_name))
         if c.input_files:
-            content.append(("inputFiles", make_unique(c.input_files.values())))
+            content.append(("inputFiles", make_unique(prepared_input_paths.values())))
         if c.output_files:
             content.append(("outputFiles", make_unique(c.output_files)))
         if c.log:

--- a/law/contrib/arc/job.py
+++ b/law/contrib/arc/job.py
@@ -426,7 +426,7 @@ class ARCJobFileFactory(BaseJobFileFactory):
 
         # prepare the executable when given
         if c.executable:
-            c.executable = rel_input_paths_sub[executable_key]
+            c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):

--- a/law/contrib/glite/job.py
+++ b/law/contrib/glite/job.py
@@ -15,7 +15,7 @@ import random
 import subprocess
 
 from law.config import Config
-from law.job.base import BaseJobManager, BaseJobFileFactory, DeprecatedInputFiles
+from law.job.base import BaseJobManager, BaseJobFileFactory, JobInputFile, DeprecatedInputFiles
 from law.target.file import add_scheme
 from law.util import interruptable_popen, make_list, make_unique, quote_cmd
 from law.logger import get_logger
@@ -309,19 +309,34 @@ class GLiteJobFileFactory(BaseJobFileFactory):
                 if c[attr]:
                     c[attr] = self.postfix_output_file(c[attr], postfix)
 
-        # ensure that the executable is an input file
-        if c.executable and c.executable not in c.input_files.values():
-            c.input_files["executable_file"] = c.executable
-
-        # add postfixed input files to render variables
-        postfixed_input_files = {
-            name: os.path.basename(self.postfix_input_file(path, postfix))
-            for name, path in c.input_files.items()
+        # ensure that all input files are JobInputFile's
+        c.input_files = {
+            key: JobInputFile(f)
+            for key, f in c.input_files.items()
         }
-        c.render_variables.update(postfixed_input_files)
+
+        # ensure that the executable is an input file, remember to key to access it
+        if c.executable:
+            executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
+            if executable_keys:
+                executable_key = executable_keys[0]
+            else:
+                executable_key = "executable_file"
+                c.input_files[executable_key] = JobInputFile(c.executable)
+
+        # add potentially postfixed input files to render variables
+        postfixed_input_paths = {
+            key: (
+                os.path.basename(self.postfix_input_file(f.path, postfix if f.postfix else None))
+                if f.copy
+                else f.path
+            )
+            for key, f in c.input_files.items()
+        }
+        c.render_variables.update(postfixed_input_paths)
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(postfixed_input_files.values())
+        c.render_variables["input_files"] = " ".join(postfixed_input_paths.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -342,11 +357,21 @@ class GLiteJobFileFactory(BaseJobFileFactory):
         job_file = self.postfix_input_file(os.path.join(c.dir, c.file_name), postfix)
 
         # prepare input files
-        def prepare_input(path):
-            path = self.provide_input(os.path.abspath(path), postfix, c.dir, render_variables)
-            return add_scheme(path, "file") if c.absolute_paths else os.path.basename(path)
+        def prepare_input(input_file):
+            # when not copied, just return the absolute, original path
+            abs_path = os.path.abspath(input_file.path)
+            if not input_file.copy:
+                return abs_path
+            # copy the file
+            abs_path = self.provide_input(
+                abs_path,
+                postfix if input_file.postfix else None,
+                c.dir,
+                render_variables if input_file.render else None,
+            )
+            return add_scheme(abs_path, "file") if c.absolute_paths else os.path.basename(abs_path)
 
-        c.input_files = {name: prepare_input(path) for name, path in c.input_files.items()}
+        prepared_input_paths = {key: prepare_input(f) for key, f in c.input_files.items()}
 
         # job file content
         content = []
@@ -354,12 +379,12 @@ class GLiteJobFileFactory(BaseJobFileFactory):
             cmd = quote_cmd(c.command) if isinstance(c.command, (list, tuple)) else c.command
             content.append(("Executable", cmd))
         elif c.executable:
-            content.append(("Executable", c.executable))
+            content.append(("Executable", os.path.basename(prepared_input_paths[executable_key])))
         if c.arguments:
             args = quote_cmd(c.arguments) if isinstance(c.arguments, (list, tuple)) else c.arguments
             content.append(("Arguments", args))
         if c.input_files:
-            content.append(("InputSandbox", make_unique(c.input_files.values())))
+            content.append(("InputSandbox", make_unique(prepared_input_paths.values())))
         if c.output_files:
             content.append(("OutputSandbox", make_unique(c.output_files)))
         if c.output_uri:

--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -360,14 +360,18 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
             c.input_files["executable_file"] = JobInputFile.create(c.executable)
 
         # add potentially postfixed input files to render variables
-        postfixed_input_basenames = {
-            name: os.path.basename(self.postfix_input_file(f.path, postfix) if f.postfix else f.path)
+        postfixed_input_paths = {
+            name: (
+                os.path.basename(self.postfix_input_file(f.path, postfix if f.postfix else None))
+                if f.copy
+                else f.path
+            )
             for name, f in c.input_files.items()
         }
-        c.render_variables.update(postfixed_input_basenames)
+        c.render_variables.update(postfixed_input_paths)
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(postfixed_input_basenames.values())
+        c.render_variables["input_files"] = " ".join(postfixed_input_paths.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:

--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -414,7 +414,7 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
 
         # prepare the executable when given
         if c.executable:
-            c.executable = rel_input_paths_sub[executable_key]
+            c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):

--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 
 from law.config import Config
-from law.job.base import BaseJobManager, BaseJobFileFactory, DeprecatedInputFiles
+from law.job.base import BaseJobManager, BaseJobFileFactory, JobInputFile, DeprecatedInputFiles
 from law.util import interruptable_popen, make_list, make_unique, quote_cmd
 from law.logger import get_logger
 
@@ -349,19 +349,25 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
                 if c[attr] and not c[attr].startswith("/dev/"):
                     c[attr] = self.postfix_output_file(c[attr], postfix)
 
+        # ensure that all input files are JobInputFile's
+        c.input_files = {
+            name: JobInputFile.create(f)
+            for name, f in c.input_files.items()
+        }
+
         # ensure that the executable is an input file
         if c.executable and c.executable not in c.input_files.values():
-            c.input_files["executable_file"] = c.executable
+            c.input_files["executable_file"] = JobInputFile.create(c.executable)
 
-        # add postfixed input files to render variables
-        postfixed_input_files = {
-            name: os.path.basename(self.postfix_input_file(path, postfix))
-            for name, path in c.input_files.items()
+        # add potentially postfixed input files to render variables
+        postfixed_input_basenames = {
+            name: os.path.basename(self.postfix_input_file(f.path, postfix) if f.postfix else f.path)
+            for name, f in c.input_files.items()
         }
-        c.render_variables.update(postfixed_input_files)
+        c.render_variables.update(postfixed_input_basenames)
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(postfixed_input_files.values())
+        c.render_variables["input_files"] = " ".join(postfixed_input_basenames.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -378,11 +384,21 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
         job_file = self.postfix_input_file(os.path.join(c.dir, c.file_name), postfix)
 
         # prepare input files
-        def prepare_input(path):
-            path = self.provide_input(os.path.abspath(path), postfix, c.dir, render_variables)
+        def prepare_input(input_file):
+            # when not copied, just return the absolute, original path
+            abs_path = os.path.abspath(input_file.path)
+            if not input_file.copy:
+                return abs_path
+            # copy the file
+            path = self.provide_input(
+                abs_path,
+                postfix if input_file.postfix else None,
+                c.dir,
+                render_variables if input_file.render else None,
+            )
             return path if c.absolute_paths else os.path.basename(path)
 
-        c.input_files = {name: prepare_input(path) for name, path in c.input_files.items()}
+        prepared_input_paths = {name: prepare_input(f) for name, f in c.input_files.items()}
 
         # prepare the executable when given
         if c.executable:
@@ -409,7 +425,7 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
         if c.input_files or c.output_files:
             content.append(("should_transfer_files", "YES"))
         if c.input_files:
-            content.append(("transfer_input_files", make_unique(c.input_files.values())))
+            content.append(("transfer_input_files", make_unique(prepared_input_paths.values())))
         if c.output_files:
             content.append(("transfer_output_files", make_unique(c.output_files)))
             content.append(("when_to_transfer_output", "ON_EXIT"))

--- a/law/contrib/htcondor/job.py
+++ b/law/contrib/htcondor/job.py
@@ -355,7 +355,7 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
             for key, f in c.input_files.items()
         }
 
-        # ensure that the executable is an input file, remember to key to access it
+        # ensure that the executable is an input file, remember the key to access it
         if c.executable:
             executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
             if executable_keys:
@@ -416,7 +416,7 @@ class HTCondorJobFileFactory(BaseJobFileFactory):
         if c.executable:
             c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
-            path = os.path.join(c.dir, c.executable)
+            path = os.path.join(c.dir, os.path.basename(c.executable))
             if os.path.exists(path):
                 os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP)
 

--- a/law/contrib/lsf/job.py
+++ b/law/contrib/lsf/job.py
@@ -16,7 +16,7 @@ import subprocess
 import six
 
 from law.config import Config
-from law.job.base import BaseJobManager, BaseJobFileFactory, DeprecatedInputFiles
+from law.job.base import BaseJobManager, BaseJobFileFactory, JobInputFile, DeprecatedInputFiles
 from law.util import interruptable_popen, make_list, make_unique, quote_cmd
 from law.logger import get_logger
 
@@ -284,19 +284,34 @@ class LSFJobFileFactory(BaseJobFileFactory):
                 if c[attr] and not c[attr].startswith("/dev/"):
                     c[attr] = self.postfix_output_file(c[attr], postfix)
 
-        # ensure that the executable is an input file
-        if c.executable and c.executable not in c.input_files.values():
-            c.input_files["executable_file"] = c.executable
-
-        # add postfixed input files to render variables
-        postfixed_input_files = {
-            name: os.path.basename(self.postfix_input_file(path, postfix))
-            for name, path in c.input_files.items()
+        # ensure that all input files are JobInputFile's
+        c.input_files = {
+            key: JobInputFile(f)
+            for key, f in c.input_files.items()
         }
-        c.render_variables.update(postfixed_input_files)
+
+        # ensure that the executable is an input file, remember to key to access it
+        if c.executable:
+            executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
+            if executable_keys:
+                executable_key = executable_keys[0]
+            else:
+                executable_key = "executable_file"
+                c.input_files[executable_key] = JobInputFile(c.executable)
+
+        # add potentially postfixed input files to render variables
+        postfixed_input_paths = {
+            key: (
+                os.path.basename(self.postfix_input_file(f.path, postfix if f.postfix else None))
+                if f.copy
+                else f.path
+            )
+            for key, f in c.input_files.items()
+        }
+        c.render_variables.update(postfixed_input_paths)
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(postfixed_input_files.values())
+        c.render_variables["input_files"] = " ".join(postfixed_input_paths.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -313,15 +328,25 @@ class LSFJobFileFactory(BaseJobFileFactory):
         job_file = self.postfix_input_file(os.path.join(c.dir, c.file_name), postfix)
 
         # prepare input files
-        def prepare_input(path):
-            path = self.provide_input(os.path.abspath(path), postfix, c.dir, render_variables)
+        def prepare_input(input_file):
+            # when not copied, just return the absolute, original path
+            abs_path = os.path.abspath(input_file.path)
+            if not input_file.copy:
+                return abs_path
+            # copy the file
+            path = self.provide_input(
+                abs_path,
+                postfix if input_file.postfix else None,
+                c.dir,
+                render_variables if input_file.render else None,
+            )
             return path if c.absolute_paths else os.path.basename(path)
 
-        c.input_files = {name: prepare_input(path) for name, path in c.input_files.items()}
+        prepared_input_paths = {key: prepare_input(f) for key, f in c.input_files.items()}
 
         # prepare the executable when given
         if c.executable:
-            c.executable = os.path.basename(self.postfix_input_file(c.executable, postfix))
+            c.executable = prepared_input_paths[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):
@@ -347,7 +372,7 @@ class LSFJobFileFactory(BaseJobFileFactory):
             content += c.custom_content
 
         if not c.manual_stagein:
-            for input_file in make_unique(c.input_files.values()):
+            for input_file in make_unique(prepared_input_paths.values()):
                 content.append(("-f", "\"{} > {}\"".format(
                     input_file, os.path.basename(input_file))))
 
@@ -358,13 +383,13 @@ class LSFJobFileFactory(BaseJobFileFactory):
 
         if c.manual_stagein:
             tmpl = "cp " + ("{}" if c.absolute_paths else "$LS_EXECCWD/{}") + " $PWD/{}"
-            for input_file in make_unique(c.input_files.values()):
+            for input_file in make_unique(prepared_input_paths.values()):
                 content.append(tmpl.format(input_file, os.path.basename(input_file)))
 
         if c.command:
             content.append(c.command)
         else:
-            content.append("." + ("" if c.executable.startswith("/") else "/") + c.executable)
+            content.append("./" + os.path.basename(prepared_input_paths[executable_key]))
         if c.arguments:
             args = quote_cmd(c.arguments) if isinstance(c.arguments, (list, tuple)) else c.arguments
             content[-1] += " {}".format(args)

--- a/law/contrib/lsf/job.py
+++ b/law/contrib/lsf/job.py
@@ -349,7 +349,7 @@ class LSFJobFileFactory(BaseJobFileFactory):
 
         # prepare the executable when given
         if c.executable:
-            c.executable = rel_input_paths_sub[executable_key]
+            c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):

--- a/law/contrib/lsf/job.py
+++ b/law/contrib/lsf/job.py
@@ -290,7 +290,7 @@ class LSFJobFileFactory(BaseJobFileFactory):
             for key, f in c.input_files.items()
         }
 
-        # ensure that the executable is an input file, remember to key to access it
+        # ensure that the executable is an input file, remember the key to access it
         if c.executable:
             executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
             if executable_keys:
@@ -351,7 +351,7 @@ class LSFJobFileFactory(BaseJobFileFactory):
         if c.executable:
             c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
-            path = os.path.join(c.dir, c.executable)
+            path = os.path.join(c.dir, os.path.basename(c.executable))
             if os.path.exists(path):
                 os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP)
 

--- a/law/contrib/slurm/job.py
+++ b/law/contrib/slurm/job.py
@@ -406,7 +406,7 @@ class SlurmJobFileFactory(BaseJobFileFactory):
 
             # add the executable
             if c.executable:
-                cmd = "." + ("" if c.executable.startswith("/") else "/") + c.executable
+                cmd = "./" + c.executable.lstrip("/")
                 f.write("\n{}{}\n".format(cmd, args))
 
         logger.debug("created slurm job file at '{}'".format(job_file))

--- a/law/contrib/slurm/job.py
+++ b/law/contrib/slurm/job.py
@@ -392,9 +392,9 @@ class SlurmJobFileFactory(BaseJobFileFactory):
 
         # prepare the executable when given
         if c.executable:
-            c.executable = rel_input_paths_job[executable_key]
+            c.executable = rel_input_paths_sub[executable_key]
             # make the file executable for the user and group
-            path = os.path.join(c.dir, c.executable)
+            path = os.path.join(c.dir, os.path.basename(c.executable))
             if os.path.exists(path):
                 os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP)
 

--- a/law/contrib/slurm/job.py
+++ b/law/contrib/slurm/job.py
@@ -368,8 +368,8 @@ class SlurmJobFileFactory(BaseJobFileFactory):
         }
 
         # add all input files to render variables
-        c.render_variables.update(rel_input_paths_job)
-        c.render_variables["input_files"] = " ".join(rel_input_paths_job.values())
+        c.render_variables.update(rel_input_paths_sub)
+        c.render_variables["input_files"] = " ".join(rel_input_paths_sub.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -392,7 +392,7 @@ class SlurmJobFileFactory(BaseJobFileFactory):
 
         # prepare the executable when given
         if c.executable:
-            c.executable = rel_input_paths_sub[executable_key]
+            c.executable = rel_input_paths_job[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):

--- a/law/contrib/slurm/job.py
+++ b/law/contrib/slurm/job.py
@@ -342,19 +342,28 @@ class SlurmJobFileFactory(BaseJobFileFactory):
                 executable_key = "executable_file"
                 c.input_files[executable_key] = JobInputFile(c.executable)
 
-        # add potentially postfixed input files to render variables
-        postfixed_input_paths = {
-            key: (
-                os.path.basename(self.postfix_input_file(f.path, postfix if f.postfix else None))
-                if f.copy
-                else f.path
-            )
-            for key, f in c.input_files.items()
+        # prepare input files
+        def prepare_input(f):
+            # when not copied, just return the absolute, original path
+            abs_path = os.path.abspath(f.path)
+            if not f.copy:
+                return abs_path
+            # copy the file
+            abs_path = self.provide_input(abs_path, postfix if f.postfix else None, c.dir)
+            return abs_path
+
+        abs_input_paths = {key: prepare_input(f) for key, f in c.input_files.items()}
+
+        # optionally convert to basenames
+        maybe_basename = lambda path: path if c.absolute_paths else os.path.basename(path)
+        maybe_rel_input_paths = {
+            key: maybe_basename(abs_path) if c.input_files[key].copy else abs_path
+            for key, abs_path in abs_input_paths.items()
         }
-        c.render_variables.update(postfixed_input_paths)
+        c.render_variables.update(maybe_rel_input_paths)
 
         # add all input files to render variables
-        c.render_variables["input_files"] = " ".join(postfixed_input_paths.values())
+        c.render_variables["input_files"] = " ".join(maybe_rel_input_paths.values())
 
         # add the custom log file to render variables
         if c.custom_log_file:
@@ -370,26 +379,14 @@ class SlurmJobFileFactory(BaseJobFileFactory):
         # prepare the job file
         job_file = self.postfix_input_file(os.path.join(c.dir, c.file_name), postfix)
 
-        # prepare input files
-        def prepare_input(input_file):
-            # when not copied, just return the absolute, original path
-            abs_path = os.path.abspath(input_file.path)
-            if not input_file.copy:
-                return abs_path
-            # copy the file
-            abs_path = self.provide_input(
-                abs_path,
-                postfix if input_file.postfix else None,
-                c.dir,
-                render_variables if input_file.render else None,
-            )
-            return abs_path if c.absolute_paths else os.path.basename(abs_path)
-
-        prepared_input_paths = {key: prepare_input(f) for key, f in c.input_files.items()}
+        # render copied input files
+        for key, abs_path in abs_input_paths.items():
+            if c.input_files[key].copy and c.input_files[key].render:
+                self.render_file(abs_path, abs_path, render_variables, postfix=postfix)
 
         # prepare the executable when given
         if c.executable:
-            c.executable = prepared_input_paths[executable_key]
+            c.executable = maybe_rel_input_paths[executable_key]
             # make the file executable for the user and group
             path = os.path.join(c.dir, c.executable)
             if os.path.exists(path):

--- a/law/contrib/slurm/job.py
+++ b/law/contrib/slurm/job.py
@@ -333,7 +333,7 @@ class SlurmJobFileFactory(BaseJobFileFactory):
             for key, f in c.input_files.items()
         }
 
-        # ensure that the executable is an input file, remember to key to access it
+        # ensure that the executable is an input file, remember the key to access it
         if c.executable:
             executable_keys = [k for k, v in c.input_files.items() if v == c.executable]
             if executable_keys:
@@ -362,7 +362,7 @@ class SlurmJobFileFactory(BaseJobFileFactory):
         }
 
         # convert to basenames as seen by the job
-        rel_input_paths_job = {
+        rel_input_paths_job = {  # noqa
             key: os.path.basename(abs_path) if c.input_files[key].copy else abs_path
             for key, abs_path in abs_input_paths.items()
         }

--- a/law/job/base.py
+++ b/law/job/base.py
@@ -21,6 +21,7 @@ from abc import ABCMeta, abstractmethod
 import six
 
 from law.config import Config
+from law.target.file import get_scheme
 from law.util import colored, make_list, iter_chunks, flatten, makedirs, create_hash
 from law.logger import get_logger
 
@@ -949,6 +950,12 @@ class JobInputFile(object):
        type: bool
 
        Whether render variables should be resolved when copied.
+
+    .. py:attribute:: is_remote
+       type: bool
+       read-only
+
+       Whether the path has a non-empty protocol referring to a remote resource.
     """
 
     def __init__(self, path, copy=True, postfix=True, render=True):
@@ -975,6 +982,10 @@ class JobInputFile(object):
         if isinstance(other, JobInputFile):
             return self.path == other.path
         return self.path == other
+
+    @property
+    def is_remote(self):
+        return get_scheme(self.path) not in ("file", None)
 
 
 class DeprecatedInputFiles(dict):

--- a/law/job/base.py
+++ b/law/job/base.py
@@ -951,12 +951,15 @@ class JobInputFile(object):
        Whether render variables should be resolved when copied.
     """
 
-    @classmethod
-    def create(cls, obj):
-        return obj if isinstance(obj, cls) else cls(obj)
-
     def __init__(self, path, copy=True, postfix=True, render=True):
         super(JobInputFile, self).__init__()
+
+        # when path is a job file instance itself, use its values instead
+        if isinstance(path, JobInputFile):
+            copy = path.copy
+            postfix = path.postfix
+            render = path.render
+            path = path.path
 
         # store attributes
         self.path = path
@@ -966,6 +969,12 @@ class JobInputFile(object):
 
     def __str__(self):
         return self.path
+
+    def __eq__(self, other):
+        # check equality via path comparison
+        if isinstance(other, JobInputFile):
+            return self.path == other.path
+        return self.path == other
 
 
 class DeprecatedInputFiles(dict):

--- a/law/job/base.py
+++ b/law/job/base.py
@@ -735,6 +735,9 @@ class BaseJobFileFactory(six.with_metaclass(ABCMeta, object)):
         In case the file content is not readable, the method returns unless *silent* is *False* in
         which case an exception is raised.
         """
+        if not os.path.isfile(src):
+            raise IOError("source file for rendering does not exist: {}".format(src))
+
         with open(src, "r") as f:
             try:
                 content = f.read()

--- a/law/parser.py
+++ b/law/parser.py
@@ -26,21 +26,25 @@ _global_cmdline_args = None
 _global_cmdline_values = None
 
 
-def root_task():
+def root_task(task=None):
     """
     Returns the instance of the task that was triggered on the command line. The returned instance
-    is cached.
+    is cached. When *task* is define and no root task was cached yet, this methods acts as a setter.
     """
     global _root_task
 
     if not _root_task:
-        luigi_parser = luigi.cmdline_parser.CmdlineParser.get_instance()
-        if not luigi_parser:
-            return None
+        if task:
+            _root_task = task
+            logger.debug("set root task to externally passed instance")
+        else:
+            luigi_parser = luigi.cmdline_parser.CmdlineParser.get_instance()
+            if not luigi_parser:
+                return None
 
-        _root_task = luigi_parser.get_task_obj()
+            _root_task = luigi_parser.get_task_obj()
 
-        logger.debug("built root task instance using luigi argument parser")
+            logger.debug("built root task instance using luigi argument parser")
 
     return _root_task
 

--- a/law/task/base.py
+++ b/law/task/base.py
@@ -311,6 +311,9 @@ class Register(BaseRegister):
     def __call__(cls, *args, **kwargs):
         inst = super(Register, cls).__call__(*args, **kwargs)
 
+        # manually set the root task once
+        root_task(inst)
+
         # check for interactive parameters
         for param in inst.interactive_params:
             value = getattr(inst, param)

--- a/law/workflow/base.py
+++ b/law/workflow/base.py
@@ -733,7 +733,7 @@ class BaseWorkflow(six.with_metaclass(WorkflowRegister, Task)):
                 return "{}_ranges_{}".format(len(ranges), create_hash(ranges))
             else:
                 return "_".join(
-                    str(r) if len(r) == 1 else "{}To{}".format(r[0], r[1] + 1)
+                    str(r[0]) if len(r) == 1 else "{}To{}".format(r[0], r[1] + 1)
                     for r in ranges
                 )
 


### PR DESCRIPTION
This PR introduces `law.JobInputFile` which is meant to improve control over job input files. It wraps an input file path, as well as three flags:

- `copy` (default `True`): Whether the file should be copied into submission directory.
- `postfix` (default `True`): When copied, whether the file should receive a string postfix.
- `render` (default `True`): When copied, whether render variables in the file should be replaced. For non-text files, it might be good to set this flag to `False`.

In the `*_job_config` hook of workflow tasks, this might look like the following (shown for the `HTCondorWorkflow`).

```python
class MyTask(..., law.htcondor.HTCondorWorkflow):

    ...

    def htcondor_job_config(self, config, job_num, branches):
        # a normal input file
        config.input_files["file_a"] = "/path/to/file"
        # same as law.JobInputFile("/path/to/file")

        # a file that should not be rendered
        config.input_files["file_b"] = law.JobInputFile("/path/to/archive.tgz", render=False)

        return config
```

Besides these additions, a couple smaller fixes are included in this PR that resolve some ambiguities that arose during handling of submission-relative and job-relative paths of input files.
