### PR TITLE
Add support for optional outputs in TargetCollection

### DIFF
--- a/law/target/collection.py
+++ b/law/target/collection.py
@@ -90,7 +90,7 @@ class TargetCollection(Target):
 
     def iter_missing(self, keys=False):
         for key, targets in self._iter_flat(keys=True):
-            if any(not t.exists() for t in targets):
+            if any(not t.optional and not t.exists() for t in targets):
                 yield (key, targets) if keys else targets
 
     def keys(self):
@@ -135,7 +135,7 @@ class TargetCollection(Target):
         # simple counting with early stopping criteria for both success and fail
         n = 0
         for i, targets in enumerate(self._iter_flat()):
-            if all(t.exists() for t in targets):
+            if all(t.optional or t.exists() for t in targets):
                 n += 1
                 if n >= threshold:
                     return True


### PR DESCRIPTION
Workflow outputs are wrapped in a TargetCollection. When some of them are optional and missing, the workflow correctly reports that it's done if all non-optional outputs are present. However, trying to depend on such a workflow doesn't work: Luigi checks .exists() before it runs the dependent task, and dies with "initially missing tasks outputs". To avoid this issue, .exists() must ignore optional outputs as is done in this patch.

Ran into this when moving the JSON control files for a workflow, which are set as optional outputs by Law itself. (See #126.)

Didn't touch the file-based collections because I'm not sure how the `threshold` parameter should be handled (which sounds more likely to be used than with a mere heterogenous TargetCollection).