### PR TITLE
Forward cache workflow between branches.

### DIFF
--- a/law/contrib/tasks/__init__.py
+++ b/law/contrib/tasks/__init__.py
@@ -224,18 +224,14 @@ class ForestMerge(LocalWorkflow):
     def is_leaf(self):
         return not self.is_forest() and self.tree_depth == self.max_tree_depth
 
-    def _create_workflow_task(self):
+    def req_workflow(self, **kwargs):
         # since the forest counts as a branch, as_workflow should point the tree_index 0
         # which is only used to compute the overall merge tree
         if self.is_forest():
-            return self._req_tree(
-                self,
-                branch=-1,
-                tree_index=0,
-                _exclude=self.exclude_params_workflow,
-            )
+            kwargs["tree_index"] = 0
+            kwargs["_skip_task_excludes"] = False
 
-        return super(ForestMerge, self)._create_workflow_task()
+        return super(ForestMerge, self).req_workflow(**kwargs)
 
     @property
     def max_tree_depth(self):

--- a/law/task/base.py
+++ b/law/task/base.py
@@ -77,6 +77,9 @@ class BaseRegister(luigi.task_register.Register):
 
 class BaseTask(six.with_metaclass(BaseRegister, luigi.Task)):
 
+    # whether to cache the result of requires() for input() and potentially also other calls
+    cache_requirements = False
+
     exclude_index = True
     exclude_params_index = set()
     exclude_params_req = set()
@@ -229,6 +232,9 @@ class BaseTask(six.with_metaclass(BaseRegister, luigi.Task)):
         # task level logger, created lazily
         self._task_logger = None
 
+        # attribute for cached requirements if enabled
+        self._cached_requirements = no_value
+
     def complete(self):
         outputs = [t for t in flatten(self.output()) if not t.optional]
 
@@ -238,6 +244,19 @@ class BaseTask(six.with_metaclass(BaseRegister, luigi.Task)):
             return False
 
         return all(t.exists() for t in outputs)
+
+    def input(self):
+        # get potentially cached requirements
+        if self.cache_requirements:
+            if self._cached_requirements is no_value:
+                self._cached_requirements = self.requires()
+            else:
+                print("BASETASK.INPUT() TAKING REQS FROM CACHE BITCHES")
+            reqs = self._cached_requirements
+        else:
+            reqs = self.requires()
+
+        return luigi.task.getpaths(reqs)
 
     @abstractmethod
     def run(self):
@@ -690,7 +709,17 @@ class WrapperTask(Task):
         return super(WrapperTask, self)._repr_flags() + ["wrapper"]
 
     def complete(self):
-        return all(task.complete() for task in flatten(self.requires()))
+        # get potentially cached requirements
+        if self.cache_requirements:
+            if self._cached_requirements is no_value:
+                self._cached_requirements = self.requires()
+            else:
+                print("WRAPPER.COMPLETE() TAKING REQS FROM CACHE BITCHES")
+            reqs = self._cached_requirements
+        else:
+            reqs = self.requires()
+
+        return all(task.complete() for task in flatten(reqs))
 
     def output(self):
         return self.input()


### PR DESCRIPTION
This PR enables the forwarding of cached objects (mainly a reference to the workflow task instance) from workflows to their branches, as well as across branches. This results in a significant speedup during instantiation and branch map creation of rather complex workflows.

Closes #138.