### PR TITLE
fixed h5py file saving

### DIFF
--- a/law/contrib/hdf5/formatter.py
+++ b/law/contrib/hdf5/formatter.py
@@ -27,4 +27,6 @@ class H5pyFormatter(Formatter):
     @classmethod
     def dump(cls, path, *args, **kwargs):
         import h5py
-        return h5py.File(get_path(path), "w", *args, **kwargs)
+        f=h5py.File(get_path(path), "w")
+        f.create_dataset(name=kwargs["name"],data=kwargs["data"],)
+        f.close()


### PR DESCRIPTION
As the dump() method for h5 files is as of now it does not save anything.
I added a few lines of code to fix it.
The function call needs to have the 2 kwargs: data and name, where data is the numpy array to save and where name is the name in the .h5
E.g.:
````
LocalFileTarget(path="/bla.hdf5",fs="foo").dump(name="test",data=array)
```