### PR TITLE
Fix for Dockerfile smell DL3048

### DIFF
--- a/docker/Dockerfile_centos7_py38
+++ b/docker/Dockerfile_centos7_py38
@@ -2,14 +2,14 @@ FROM centos:7
 
 # labels
 LABEL law.version="0.1.12"
-LABEL law.image_name="riga/law"
-LABEL law.image_tag="c7-py38"
-LABEL law.image_os="centos7"
-LABEL law.image_python_major="3"
-LABEL law.image_python_minor="8"
-LABEL law.image_python_patch="15"
-LABEL law.image_python="3.8.15"
-LABEL law.image_python_mm="3.8"
+LABEL law.image-name="riga/law"
+LABEL law.image-tag="c7-py38"
+LABEL law.image-os="centos7"
+LABEL law.image-python-major="3"
+LABEL law.image-python-minor="8"
+LABEL law.image-python-patch="15"
+LABEL law.image-python="3.8.15"
+LABEL law.image-python-mm="3.8"
 
 # law specific environment variables
 ENV LAW_IMAGE_ROOT /root/law


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/Dockerfile_centos7_py38" contains the best practice violation [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3048 occurs when the pattern used for the label keys does not match the format recommended by official guidelines.
In this pull request, we propose a fix for that smell generated by our fixing tool. We manually checked that the patch is correct before opening the pull request.
To fix this smell, specifically, the label keys are refactored to match the correct format.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.