### PR TITLE
Passthrough workflow type.

### DIFF
--- a/law/task/base.py
+++ b/law/task/base.py
@@ -713,8 +713,6 @@ class WrapperTask(Task):
         if self.cache_requirements:
             if self._cached_requirements is no_value:
                 self._cached_requirements = self.requires()
-            else:
-                print("WRAPPER.COMPLETE() TAKING REQS FROM CACHE BITCHES")
             reqs = self._cached_requirements
         else:
             reqs = self.requires()


### PR DESCRIPTION
This PR changes the way the `--workflow TYPE` parameter is passed between (workflow) tasks.
Considering the following scenario,

```mermaid
graph TD
    A("TaskA (HTCondorWorkflow, LocalWorkflow)")
    B("TaskB (LocalWorkflow)")
    C("TaskC (HTCondorWorkflow, LocalWorkflow)")

    A --> B
    B --> C
```

running `law run TaskC --workflow htcondor` will currently

- (correctly) trigger TaskC to run on htcondor, before that
- (correctly) trigger TaskB to run locally, and before that
- (incorrectly?) trigger TaskA to run locally as well.
Generally one would want to run **TaskA on htcondor as well**, but since TaskB is not able to do so, it will pass it's own workflow type, `"local"`, upstream to TaskA.

In the current state, this could be avoided by configuring the requirements from TaskB to TaskA in a way that the task-level CLI parameter `--TaskA-workflow` would have preference, and then running `law run TaskC --workflow htcondor --TaskA-workflow htcondor`, but this is somewhat cumbersome and unexpected.

This PR stores the **requested** workflow type in a different parameter than the **effective** one and passes the former upstream (instead of the latter one). This is the new default behavior, which can be toggled back to the above description by setting `passthrough_requested_workflow = False` on task class level.