### PR TITLE
Fix TypeError causing function call

### DIFF
--- a/law/workflow/base.py
+++ b/law/workflow/base.py
@@ -1323,7 +1323,7 @@ class BaseWorkflow(six.with_metaclass(WorkflowRegister, ProxyAttributeTask)):
         # create a new workflow instance
         kwargs["_exclude"] = set(kwargs.get("_exclude", set())) | {"branches"}
         kwargs["_skip_task_excludes"] = True
-        wf = self.req_workflow(self, **kwargs)
+        wf = self.req_workflow(**kwargs)
 
         # return its branch chunks
         return wf.get_branch_chunks(chunk_size)


### PR DESCRIPTION
Class instance `self` was given as positional argument although `req_workflow` is a class method with native access to `self`. This wasn't a problem with the previous implementation using `req` directly without the new helper method `req_workflow` introduced in commit https://github.com/riga/law/commit/7d4f6793baff103cd69bf6c88ac446ffb37a3402#diff-797a1ce240571ca7714bd6fb314f3eaa3e1e241982c9a8ee48cdfbf6e4c72394L1025-R1056.