### PR TITLE
Add htcondor group submission.

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -78,7 +78,7 @@ jobs:
         run: ./tests/docker.sh riga/law ./tests/coverage.sh
 
       - name: Upload report 🔝
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -52,7 +52,7 @@ jobs:
     name: test (python ${{ matrix.python }})
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/docs/api/cli/index.rst
+++ b/docs/api/cli/index.rst
@@ -12,3 +12,5 @@ law.cli
    completion
    config
    software
+   quickstart
+   luigid

--- a/docs/api/cli/luigid.rst
+++ b/docs/api/cli/luigid.rst
@@ -1,0 +1,5 @@
+law.cli.luigid
+==============
+
+.. automodule:: law.cli.luigid
+   :members:

--- a/docs/api/cli/quickstart.rst
+++ b/docs/api/cli/quickstart.rst
@@ -1,0 +1,5 @@
+law.cli.quickstart
+==================
+
+.. automodule:: law.cli.quickstart
+   :members:

--- a/law.cfg.example
+++ b/law.cfg.example
@@ -844,9 +844,17 @@
 ; values above are used. The only exception is "htcondor_job_file_dir_cleanup" whose default value
 ; is False.
 
+; htcondor_job_grouping_submit
+; Desciption: Whether to use job grouping (cluster submission in HTCondor nomenclature) or not. If
+; not, the standard batched submission is used and settings such as "htcondor_chunk_size_submit" and
+; "htcondor_merge_job_files" are considered.
+; Type: boolean
+; Default: True
+
 ; htcondor_chunk_size_submit
 ; Description: Number of jobs that can be submitted in parallel inside a single call to
-; "law.htcondor.HTCondorJobManager.submit", i.e., in a single "condor_submit" command.
+; "law.htcondor.HTCondorJobManager.submit", i.e., in a single "condor_submit" command. Ignored when
+; job grouping is enabled in "htcondor_job_grouping_submit".
 ; Type: integer
 ; Default: 25
 
@@ -864,8 +872,9 @@
 
 ; htcondor_merge_job_files
 ; Description: A boolean flag that decides whether multiple job description files should be merged
-; into a single file before submission. When "False", the "htcondor_chunk_size_submit" option is
-; not considered either.
+; into a single file before submission. Ignored when job grouping is enabled in
+; "htcondor_job_grouping_submit". When "False", the "htcondor_chunk_size_submit" option is not
+; considered either.
 ; Type: boolean
 ; Default: True
 

--- a/law/cli/cli.py
+++ b/law/cli/cli.py
@@ -12,7 +12,7 @@ from argparse import ArgumentParser
 import law
 
 
-progs = ["run", "index", "config", "software", "completion", "location", "quickstart"]
+progs = ["run", "index", "config", "software", "completion", "location", "quickstart", "luigid"]
 
 
 def run(argv=None):
@@ -51,13 +51,14 @@ def run(argv=None):
     # argv that is passed to the prog execution when set
     prog_argv = None
 
-    # parse args and dispatch execution, with "run" being a special case
+    # parse args and dispatch execution, considering some special cases
     prog = argv[0] if argv else None
     if prog == "run":
-        # only pass the prog and the task family to the parser
-        # and let luigi's parsing handle the rest downstream in execute
         args = parser.parse_args(argv[:2])
         prog_argv = ["law run"] + argv
+    elif prog == "luigid":
+        args = parser.parse_args(argv[:1])
+        prog_argv = ["law luigid"] + argv
     else:
         args = parser.parse_args(argv)
 

--- a/law/cli/completion.sh
+++ b/law/cli/completion.sh
@@ -26,7 +26,7 @@ _law_complete() {
     local index_file="${LAW_INDEX_FILE:-${law_home}/index}"
 
     # common parameters
-    local common_params="run index config software completion location quickstart --help --version"
+    local common_params="run index config software completion location quickstart luigid --help --version"
 
     # the current word
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -199,6 +199,14 @@ _law_complete() {
     # complete the "quickstart" subcommand
     elif [ "${sub_cmd}" = "quickstart" ]; then
         local words="help directory no-tasks no-config no-setup"
+        local inp="${cur##-}"
+        inp="${inp##-}"
+        COMPREPLY=( $( compgen -W "$( echo ${words} )" -P "--" -- "${inp}" ) )
+        return "0"
+
+    # complete the "luigid" subcommand
+    elif [ "${sub_cmd}" = "luigid" ]; then
+        local words="help background pidfile logdir state-path address unix-socket port"
         local inp="${cur##-}"
         inp="${inp##-}"
         COMPREPLY=( $( compgen -W "$( echo ${words} )" -P "--" -- "${inp}" ) )

--- a/law/cli/luigid.py
+++ b/law/cli/luigid.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+
+"""
+"law luigid" cli subprogram.
+"""
+
+
+from law.config import Config
+
+
+def setup_parser(sub_parsers):
+    """
+    Sets up the command line parser for the *luigid* subprogram and adds it to *sub_parsers*.
+    This is identical to running ``luigid`` directly from the command line, but this also loads the
+    law config prior to starting the scheduler process and optionally syncrhonizes it with luigi's
+    config.
+    """
+    parser = sub_parsers.add_parser(
+        "luigid",
+        prog="law luigid",
+        description="Starts the 'luigid' central scheduler.",
+        add_help=False,
+    )
+
+    parser.add_argument(
+        "arguments",
+        nargs="*",
+        help="luigid arguments",
+    )
+
+
+def execute(args, argv):
+    """
+    Initializes the law config object and executes the *luigid* subprogram with parsed commandline
+    *args*.
+    """
+    # initialize the config
+    Config.instance()
+
+    # forward to luigid
+    from luigi.cmdline import luigid
+    luigid(argv[2:])

--- a/law/cli/run.py
+++ b/law/cli/run.py
@@ -8,8 +8,6 @@
 import os
 import sys
 
-from luigi.cmdline import luigi_run
-
 from law.config import Config
 from law.task.base import Task
 from law.util import abort
@@ -90,6 +88,7 @@ def execute(args, argv):
         abort("task '{}' not found".format(args.task_family))
 
     # run luigi
+    from luigi.cmdline import luigi_run
     sys.argv[0] += " run"
     luigi_run([task_family] + argv[3:])
 

--- a/law/contrib/cms/crab/crab_wrapper.sh
+++ b/law/contrib/cms/crab/crab_wrapper.sh
@@ -158,15 +158,17 @@ EOF
         [ "${input_file_render_base}" = "${this_file_base}" ] && continue
         # render
         echo "render ${input_file_render}"
-        _law_python -c "\
-import re;\
-repl = ${render_variables};\
-repl['input_files_render'] = '';\
-content = open('${input_file_render}', 'r').read();\
-content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content);\
-open('${input_file_render_base}', 'w').write(content);\
-"
+        cat > _render.py << EOT
+import re
+repl = ${render_variables}
+repl['input_files_render'] = ''
+content = open('${input_file_render}', 'r').read()
+content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content)
+open('${input_file_render_base}', 'w').write(content)
+EOT
+        _law_python _render.py
         local render_ret="$?"
+        rm -f _render.py
         # handle rendering errors
         if [ "${render_ret}" != "0" ]; then
             >&2 echo "input file rendering failed with code ${render_ret}"

--- a/law/contrib/cms/job.py
+++ b/law/contrib/cms/job.py
@@ -56,7 +56,10 @@ class CrabJobManager(BaseJobManager):
 
     log_file_pattern = "https://cmsweb.cern.ch:8443/scheddmon/{scheduler_id}/{user}/{task_name}/job_out.{crab_num}.{attempt}.txt"  # noqa
 
-    job_grouping = True
+    job_grouping_submit = True
+    job_grouping_query = True
+    job_grouping_cancel = True
+    job_grouping_cleanup = True
 
     JobId = namedtuple("JobId", ["crab_num", "task_name", "proj_dir"])
 

--- a/law/contrib/cms/workflow.py
+++ b/law/contrib/cms/workflow.py
@@ -160,7 +160,7 @@ class CrabWorkflowProxy(BaseRemoteWorkflowProxy):
             c.custom_log_file = log_file
 
         # task hook
-        c = task.crab_job_config(c, submit_jobs)
+        c = task.crab_job_config(c, list(submit_jobs.keys()), list(submit_jobs.values()))
 
         # build the job file and get the sanitized config
         job_file, c = self.job_file_factory(**c.__dict__)

--- a/law/contrib/htcondor/config.py
+++ b/law/contrib/htcondor/config.py
@@ -8,6 +8,7 @@ Function returning the config defaults of the htcondor package.
 def config_defaults(default_config):
     return {
         "job": {
+            "htcondor_job_grouping_submit": True,
             "htcondor_job_file_dir": None,
             "htcondor_job_file_dir_mkdtemp": None,
             "htcondor_job_file_dir_cleanup": False,

--- a/law/contrib/htcondor/htcondor_wrapper.sh
+++ b/law/contrib/htcondor/htcondor_wrapper.sh
@@ -75,17 +75,19 @@ htcondor_wrapper() {
         [ "${input_file_render_base}" = "${this_file_base}" ] && continue
         # render
         echo "render ${input_file_render}"
-        _law_python -c "\
-import re;\
-repl = ${render_variables};\
-repl['input_files_render'] = '';\
-repl['file_postfix'] = '${file_postfix}' or repl.get('file_postfix', '');\
-repl['log_file'] = '${log_file}' or repl.get('log_file', '');\
-content = open('${input_file_render}', 'r').read();\
-content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content);\
-open('${input_file_render_base}', 'w').write(content);\
-"
+        cat > _render.py << EOT
+import re
+repl = ${render_variables}
+repl['input_files_render'] = ''
+repl['file_postfix'] = '${file_postfix}' or repl.get('file_postfix', '')
+repl['log_file'] = '${log_file}' or repl.get('log_file', '')
+content = open('${input_file_render}', 'r').read()
+content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content)
+open('${input_file_render_base}', 'w').write(content)
+EOT
+        _law_python _render.py
         local render_ret="$?"
+        rm -f _render.py
         # handle rendering errors
         if [ "${render_ret}" != "0" ]; then
             >&2 echo "input file rendering failed with code ${render_ret}"

--- a/law/contrib/htcondor/htcondor_wrapper.sh
+++ b/law/contrib/htcondor/htcondor_wrapper.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+# Wrapper script that is to be configured as htcondor's main executable file
+
+htcondor_wrapper() {
+    # helper to select the correct python executable
+    _law_python() {
+        command -v python &> /dev/null && python "$@" || python3 "$@"
+    }
+
+    #
+    # detect variables
+    #
+
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
+    local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local this_file_base="$( basename "${this_file}" )"
+
+    # get the job number
+    export LAW_HTCONDOR_JOB_NUMBER="${LAW_HTCONDOR_JOB_PROCESS}"
+    if [ -z "${LAW_HTCONDOR_JOB_NUMBER}" ]; then
+        >&2 echo "could not determine htcondor job number"
+        return "1"
+    fi
+    # htcondor process numbers start at 0, law job numbers at 1, so increment
+    ((LAW_HTCONDOR_JOB_NUMBER++))
+    echo "running ${this_file_base} for job number ${LAW_HTCONDOR_JOB_NUMBER}"
+
+
+    #
+    # job argument definitons, depending on LAW_HTCONDOR_JOB_NUMBER
+    #
+
+    # definition
+    local htcondor_job_arguments_map
+    declare -A htcondor_job_arguments_map
+    htcondor_job_arguments_map=(
+        {{htcondor_job_arguments_map}}
+    )
+
+    # pick
+    local htcondor_job_arguments="${htcondor_job_arguments_map[${LAW_HTCONDOR_JOB_NUMBER}]}"
+    if [ -z "${htcondor_job_arguments}" ]; then
+        >&2 echo "empty htcondor job arguments for LAW_HTCONDOR_JOB_NUMBER ${LAW_HTCONDOR_JOB_NUMBER}"
+        return "3"
+    fi
+
+
+    #
+    # variable rendering
+    #
+
+    # check variables
+    local render_variables="{{render_variables}}"
+    if [ -z "${render_variables}" ]; then
+        >&2 echo "empty render variables"
+        return "4"
+    fi
+
+    # decode
+    render_variables="$( echo "${render_variables}" | base64 --decode )"
+
+    # check files to render
+    local input_files_render=( {{input_files_render}} )
+    if [ "${#input_files_render[@]}" == "0" ]; then
+        >&2 echo "received empty input files for rendering for LAW_HTCONDOR_JOB_NUMBER ${LAW_HTCONDOR_JOB_NUMBER}"
+        return "5"
+    fi
+
+    # render files
+    local input_file_render
+    for input_file_render in ${input_files_render[@]}; do
+        # skip if the file refers to _this_ one
+        local input_file_render_base="$( basename "${input_file_render}" )"
+        [ "${input_file_render_base}" = "${this_file_base}" ] && continue
+        # render
+        echo "render ${input_file_render}"
+        _law_python -c "\
+import re;\
+repl = ${render_variables};\
+repl['input_files_render'] = '';\
+repl['file_postfix'] = '${file_postfix}' or repl.get('file_postfix', '');\
+repl['log_file'] = '${log_file}' or repl.get('log_file', '');\
+content = open('${input_file_render}', 'r').read();\
+content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content);\
+open('${input_file_render_base}', 'w').write(content);\
+"
+        local render_ret="$?"
+        # handle rendering errors
+        if [ "${render_ret}" != "0" ]; then
+            >&2 echo "input file rendering failed with code ${render_ret}"
+            return "6"
+        fi
+    done
+
+
+    #
+    # run the actual job file
+    #
+
+    # check the job file
+    local job_file="{{job_file}}"
+    if [ ! -f "${job_file}" ]; then
+        >&2 echo "job file '${job_file}' does not exist"
+        return "7"
+    fi
+
+    # helper to print a banner
+    banner() {
+        local msg="$1"
+
+        echo
+        echo "================================================================================"
+        echo "=== ${msg}"
+        echo "================================================================================"
+        echo
+    }
+
+    # debugging: print its contents
+    # echo "=== content of job file '${job_file}'"
+    # echo
+    # cat "${job_file}"
+    # echo
+    # echo "=== end of job file content"
+
+    # run it
+    banner "Start of law job"
+
+    local job_ret
+    bash "${job_file}" ${htcondor_job_arguments}
+    job_ret="$?"
+
+    banner "End of law job"
+
+    return "${job_ret}"
+}
+
+action() {
+    # arguments: file_postfix, log_file
+    local file_postfix="$1"
+    local log_file="$2"
+
+    if [ -z "${log_file}" ]; then
+        htcondor_wrapper "$@"
+    elif command -v tee &> /dev/null; then
+        set -o pipefail
+        echo "---" >> "${log_file}"
+        htcondor_wrapper "$@" 2>&1 | tee -a "${log_file}"
+    else
+        echo "---" >> "${log_file}"
+        htcondor_wrapper "$@" &>> "${log_file}"
+    fi
+}
+
+action "$@"

--- a/law/contrib/htcondor/workflow.py
+++ b/law/contrib/htcondor/workflow.py
@@ -246,6 +246,13 @@ class HTCondorWorkflow(BaseRemoteWorkflow):
     def htcondor_workflow_requires(self):
         return DotDict()
 
+    def htcondor_job_resources(self, job_num, branches):
+        """
+        Hook to define resources for a specific job with number *job_num*, processing *branches*.
+        This method should return a dictionary.
+        """
+        return {}
+
     def htcondor_bootstrap_file(self):
         return None
 

--- a/law/contrib/htcondor/workflow.py
+++ b/law/contrib/htcondor/workflow.py
@@ -14,12 +14,12 @@ from collections import OrderedDict
 import luigi
 
 from law.workflow.remote import BaseRemoteWorkflow, BaseRemoteWorkflowProxy
-from law.job.base import JobArguments, JobInputFile, DeprecatedInputFiles
+from law.job.base import JobArguments, JobInputFile
 from law.task.proxy import ProxyCommand
 from law.target.file import get_path, get_scheme, FileSystemDirectoryTarget
 from law.target.local import LocalDirectoryTarget
 from law.parameter import NO_STR
-from law.util import law_src_path, merge_dicts, DotDict
+from law.util import law_src_path, merge_dicts, DotDict, rel_path
 from law.logger import get_logger
 
 from law.contrib.htcondor.job import HTCondorJobManager, HTCondorJobFileFactory
@@ -38,28 +38,38 @@ class HTCondorWorkflowProxy(BaseRemoteWorkflowProxy):
     def create_job_file_factory(self, **kwargs):
         return self.task.htcondor_create_job_file_factory(**kwargs)
 
-    def create_job_file(self, job_num, branches):
+    def create_job_file(self, *args):
         task = self.task
 
-        # the file postfix is pythonic range made from branches, e.g. [0, 1, 2, 4] -> "_0To5"
-        postfix = "_{}To{}".format(branches[0], branches[-1] + 1)
+        grouped_submission = len(args) == 1
+        if grouped_submission:
+            submit_jobs = args[0]
+        else:
+            job_num, branches = args
 
         # create the config
         c = self.job_file_factory.get_config()
-        c.input_files = DeprecatedInputFiles()
+        c.input_files = {}
         c.output_files = []
         c.render_variables = {}
         c.custom_content = []
 
-        # get the actual wrapper file that will be executed by the remote job
-        wrapper_file = task.htcondor_wrapper_file()
+        # get the actual wrapper and job file that will be executed by the remote job
         law_job_file = task.htcondor_job_file()
-        if wrapper_file and get_path(wrapper_file) != get_path(law_job_file):
+        c.input_files["job_file"] = law_job_file
+        if grouped_submission:
+            # grouped wrapper file
+            wrapper_file = task.htcondor_group_wrapper_file()
             c.input_files["executable_file"] = wrapper_file
             c.executable = wrapper_file
         else:
-            c.executable = law_job_file
-        c.input_files["job_file"] = law_job_file
+            # standard wrapper file
+            wrapper_file = task.htcondor_wrapper_file()
+            if wrapper_file and get_path(wrapper_file) != get_path(law_job_file):
+                c.input_files["executable_file"] = wrapper_file
+                c.executable = wrapper_file
+            else:
+                c.executable = law_job_file
 
         # collect task parameters
         exclude_args = (
@@ -70,7 +80,7 @@ class HTCondorWorkflowProxy(BaseRemoteWorkflowProxy):
             {"workflow", "effective_workflow"}
         )
         proxy_cmd = ProxyCommand(
-            task.as_branch(branches[0]),
+            task.as_branch(0 if grouped_submission else branches[0]),
             exclude_task_args=exclude_args,
             exclude_global_args=["workers", "local-scheduler", task.task_family + "-*"],
         )
@@ -79,17 +89,34 @@ class HTCondorWorkflowProxy(BaseRemoteWorkflowProxy):
         for key, value in OrderedDict(task.htcondor_cmdline_args()).items():
             proxy_cmd.add_arg(key, value, overwrite=True)
 
-        # job script arguments
-        job_args = JobArguments(
-            task_cls=task.__class__,
-            task_params=proxy_cmd.build(skip_run=True),
-            branches=branches,
-            workers=task.job_workers,
-            auto_retry=False,
-            dashboard_data=self.dashboard.remote_hook_data(
-                job_num, self.job_data.attempts.get(job_num, 0)),
-        )
-        c.arguments = job_args.join()
+        # the file postfix is pythonic range made from branches, e.g. [0, 1, 2, 4] -> "_0To5"
+        if grouped_submission:
+            c.postfix = [
+                "_{}To{}".format(branches[0], branches[-1] + 1)
+                for branches in submit_jobs.values()
+            ]
+        else:
+            c.postfix = "_{}To{}".format(branches[0], branches[-1] + 1)
+
+        # job script arguments per job number
+        def get_job_args(job_num, branches):
+            return JobArguments(
+                task_cls=task.__class__,
+                task_params=proxy_cmd.build(skip_run=True),
+                branches=branches,
+                workers=task.job_workers,
+                auto_retry=False,
+                dashboard_data=self.dashboard.remote_hook_data(
+                    job_num, self.job_data.attempts.get(job_num, 0)),
+            )
+
+        if grouped_submission:
+            c.arguments = [
+                get_job_args(job_num, branches).join()
+                for job_num, branches in submit_jobs.items()
+            ]
+        else:
+            c.arguments = get_job_args(job_num, branches).join()
 
         # add the bootstrap file
         bootstrap_file = task.htcondor_bootstrap_file()
@@ -128,14 +155,17 @@ class HTCondorWorkflowProxy(BaseRemoteWorkflowProxy):
             c.custom_content.append(("initialdir", output_dir.abspath))
 
         # task hook
-        c = task.htcondor_job_config(c, job_num, branches)
+        if grouped_submission:
+            c = task.htcondor_job_config(c, list(submit_jobs.keys()), list(submit_jobs.values()))
+        else:
+            c = task.htcondor_job_config(c, job_num, branches)
 
         # when the output dir is not local, direct output files are not possible
         if not output_dir_is_local:
             del c.output_files[:]
 
         # build the job file and get the sanitized config
-        job_file, c = self.job_file_factory(postfix=postfix, **c.__dict__)
+        job_file, c = self.job_file_factory(grouped_submission=grouped_submission, **c.__dict__)
 
         # get the location of the custom local log file if any
         abs_log_file = None
@@ -144,6 +174,26 @@ class HTCondorWorkflowProxy(BaseRemoteWorkflowProxy):
 
         # return job and log files
         return {"job": job_file, "config": c, "log": abs_log_file}
+
+    def _submit_group(self, *args, **kwargs):
+        job_ids, submission_data = super(HTCondorWorkflowProxy, self)._submit_group(*args, **kwargs)
+
+        # when a log file is present, replace certain htcondor variables
+        for i, (job_id, data) in enumerate(zip(job_ids, submission_data.values())):
+            log = data.get("log")
+            if not log:
+                continue
+            # replace Cluster, ClusterId, Process, ProcId
+            c, p = job_id.split(".")
+            log = log.replace("$(Cluster)", c).replace("$(ClusterId)", c)
+            log = log.replace("$(Process)", p).replace("$(ProcId)", p)
+            # replace law_job_postfix
+            if data["config"].postfix_output_files and data["config"].postfix:
+                log = log.replace("$(law_job_postfix)", data["config"].postfix[i])
+            # add back
+            data["log"] = log
+
+        return job_ids, submission_data
 
     def destination_info(self):
         info = super(HTCondorWorkflowProxy, self).destination_info()
@@ -199,11 +249,24 @@ class HTCondorWorkflow(BaseRemoteWorkflow):
     def htcondor_bootstrap_file(self):
         return None
 
+    def htcondor_group_wrapper_file(self):
+        # only used for grouped submissions
+        return JobInputFile(
+            path=rel_path(__file__, "htcondor_wrapper.sh"),
+            copy=True,
+            render_local=True,
+        )
+
     def htcondor_wrapper_file(self):
         return None
 
     def htcondor_job_file(self):
-        return JobInputFile(law_src_path("job", "law_job.sh"))
+        return JobInputFile(
+            path=law_src_path("job", "law_job.sh"),
+            copy=True,
+            share=True,
+            render_job=True,
+        )
 
     def htcondor_stageout_file(self):
         return None

--- a/law/job/base.py
+++ b/law/job/base.py
@@ -111,41 +111,63 @@ class BaseJobManager(six.with_metaclass(ABCMeta, object)):
         A dictionary that defines to coloring styles per job status that is used in
         :py:meth:`status_line`.
 
-    .. py:classattribute:: job_grouping
+    .. py:classattribute:: job_grouping_submit
 
         type: bool
 
-        Whether this manager implementation groups jobs into single interactions for submission and
-        status queries. In general, this means that the submission of a single job file can result
-        in multiple jobs on the remote batch system.
+        Whether this manager implementation groups jobs into single interactions for submission. In
+        general, this means that the submission of a single job file can result in multiple jobs on
+        the remote batch system.
+
+    .. py:classattribute:: job_grouping_cancel
+
+        type: bool
+
+        Whether this manager implementation groups jobs into single interactions for cancelling
+        jobs.
+
+    .. py:classattribute:: job_grouping_cleanup
+
+        type: bool
+
+        Whether this manager implementation groups jobs into single interactions for cleaning up
+        jobs.
+
+    .. py:classattribute:: job_grouping_query
+
+        type: bool
+
+        Whether this manager implementation groups jobs into single interactions for querying job
+        statuses.
 
     .. py:classattribute:: chunk_size_submit
 
         type: int
 
-        The default chunk size value when no value is given in :py:meth:`submit_batch`. When the
-        value evaluates to *False*, no chunking is allowed.
+        The default chunk size value when no value is given in :py:meth:`submit_batch`. If the value
+        evaluates to *False*, no chunking is allowed.
+
 
     .. py:classattribute:: chunk_size_cancel
 
         type: int
 
-        The default chunk size value when no value is given in :py:meth:`cancel_batch`. When the
-        value evaluates to *False*, no chunking is allowed.
+        The default chunk size value when no value is given in :py:meth:`cancel_batch`. If the value
+        evaluates to *False*, no chunking is allowed.
 
     .. py:classattribute:: chunk_size_cleanup
 
         type: int
 
-        The default chunk size value when no value is given in :py:meth:`cleanup_batch`. When the
+        The default chunk size value when no value is given in :py:meth:`cleanup_batch`. If the
         value evaluates to *False*, no chunking is allowed.
 
     .. py:classattribute:: chunk_size_query
 
         type: int
 
-        The default chunk size value when no value is given in :py:meth:`query_batch`. When the
-        value evaluates to *False*, no chunking is allowed.
+        The default chunk size value when no value is given in :py:meth:`query_batch`. If the value
+        evaluates to *False*, no chunking is allowed.
     """
 
     PENDING = "pending"
@@ -165,8 +187,11 @@ class BaseJobManager(six.with_metaclass(ABCMeta, object)):
         FAILED: ({}, {}, {"color": "red", "style": "bright"}),
     }
 
-    # job grouping settings
-    job_grouping = False
+    # job grouping settings per method
+    job_grouping_submit = False
+    job_grouping_cancel = False
+    job_grouping_cleanup = False
+    job_grouping_query = False
 
     # chunking settings for unbatched methods
     # disabled by default
@@ -238,10 +263,10 @@ class BaseJobManager(six.with_metaclass(ABCMeta, object)):
     def group_job_ids(self, job_ids):
         """
         Hook that needs to be implemented if the job mananger supports grouping of jobs, i.e., when
-        :py:attr:`job_grouping` is *True*, and potentially used during status queries, job
-        cancellation and removal. If so, it should take a sequence of *job_ids* and return a
-        dictionary mapping ids of group jobs (used for queries etc) to the corresponding lists of
-        original job ids, with an arbitrary grouping mechanism.
+        :py:attr:`job_grouping_submit`, :py:attr:`job_grouping_query`, etc. is *True*, and
+        potentially used during status queries, job cancellation and removal. If so, it should take
+        a sequence of *job_ids* and return a dictionary mapping ids of group jobs (used for queries
+        etc) to the corresponding lists of original job ids, with an arbitrary grouping mechanism.
         """
         raise NotImplementedError(
             "internal error, {}.group_job_ids not implemented".format(self.__class__.__name__),

--- a/law/job/law_job.sh
+++ b/law/job/law_job.sh
@@ -602,10 +602,10 @@ start_law_job() {
             law_job "$@"
         elif command -v tee &> /dev/null; then
             set -o pipefail
-            echo -e "" > "${log_file}"
+            echo "---" >> "${log_file}"
             law_job "$@" 2>&1 | tee -a "${log_file}"
         else
-            echo -e "" > "${log_file}"
+            echo "---" >> "${log_file}"
             law_job "$@" &>> "${log_file}"
         fi
     fi

--- a/law/job/law_job.sh
+++ b/law/job/law_job.sh
@@ -456,7 +456,6 @@ law_job() {
     fi
 
     # handle input file rendering
-    local render_ret
     render_variables="$( echo "${render_variables}" | base64 --decode )"
     if [ "${#input_files_render[@]}" != "0" ] && [ ! -z "${render_variables}" ] && [ "${render_variables}" != "-" ]; then
         echo
@@ -473,14 +472,16 @@ law_job() {
             [ "${input_file_render:0:1}" != "/" ] && input_file_render="${LAW_JOB_INIT_DIR}/${input_file_render}"
             # render
             echo "render ${input_file_render}"
-            _law_python -c "\
-import re;\
-repl = ${render_variables};\
-content = open('${input_file_render}', 'r').read();\
-content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content);\
-open('${input_file_render_base}', 'w').write(content);\
-"
-            render_ret="$?"
+            cat > _render.py << EOT
+import re
+repl = ${render_variables}
+content = open('${input_file_render}', 'r').read()
+content = re.sub(r'\{\{(\w+)\}\}', lambda m: repl.get(m.group(1), ''), content)
+open('${input_file_render_base}', 'w').write(content)
+EOT
+            _law_python _render.py
+            local render_ret="$?"
+            rm -f _render.py
             # handle rendering errors
             if [ "${render_ret}" != "0" ]; then
                 >&2 echo "input file rendering failed (exit code ${render_ret}), stop job"

--- a/law/target/collection.py
+++ b/law/target/collection.py
@@ -157,7 +157,7 @@ class TargetCollection(Target):
 
         # simple counting with early stopping criteria for both success and fail cases
         n = 0
-        for i, targets in enumerate(self.iter_existing(**kwargs)):
+        for i, _ in enumerate(self.iter_existing(**kwargs)):
             n += 1
 
             # check for early success

--- a/law/task/base.py
+++ b/law/task/base.py
@@ -8,7 +8,6 @@ __all__ = ["Task", "WrapperTask", "ExternalTask"]
 
 
 import sys
-import socket
 import logging
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -86,12 +85,6 @@ class BaseTask(six.with_metaclass(BaseRegister, luigi.Task)):
     exclude_params_req_set = set()
     exclude_params_req_get = set()
     prefer_params_cli = set()
-
-    @staticmethod
-    def resource_name(name, host=None):
-        if host is None:
-            host = socket.gethostname().partition(".")[0]
-        return "{}_{}".format(host, name)
 
     @classmethod
     def deregister(cls, task_cls=None):

--- a/law/workflow/base.py
+++ b/law/workflow/base.py
@@ -76,7 +76,7 @@ class BaseWorkflowProxy(ProxyTask):
 
         self._workflow_has_reset_branch_map = False
 
-    def _get_task_attribute(self, name, fallback=False):
+    def _get_task_attribute(self, name, fallback=True):
         """
         Return an attribute of the actual task named ``<workflow_type>_<name>``. When the attribute
         does not exist and *fallback* is *True*, try to return the task attribute simply named
@@ -88,10 +88,9 @@ class BaseWorkflowProxy(ProxyTask):
         if isinstance(name, (list, tuple)):
             attributes = name
         else:
-            attributes = [
-                "{}_{}".format(self.workflow_type, name),
-                name,
-            ]
+            attributes = ["{}_{}".format(self.workflow_type, name)]
+            if fallback:
+                attributes.append(name)
 
         for attr in attributes:
             value = getattr(self.task, attr, no_value)

--- a/law/workflow/remote.py
+++ b/law/workflow/remote.py
@@ -591,10 +591,12 @@ class BaseRemoteWorkflowProxy(BaseWorkflowProxy):
             self.dashboard.apply_config(self.job_data.dashboard_config)
 
         # store the initially complete branches
+        outputs_existing = False
         if "collection" in self._outputs:
             collection = self._outputs["collection"]
             count, keys = collection.count(keys=True)
             self._initially_existing_branches = keys
+            outputs_existing = count >= collection._abs_threshold()
 
         # cancel jobs?
         if self._cancel_jobs:
@@ -608,6 +610,10 @@ class BaseRemoteWorkflowProxy(BaseWorkflowProxy):
             if self._submitted:
                 self.cleanup()
             self._controlled_jobs = True
+            return
+
+        # were all outputs already existing?
+        if outputs_existing:
             return
 
         # from here on, submit and/or wait while polling


### PR DESCRIPTION
This PR mainly contains the group submission of htcondor jobs (detailed below). However, there are two smaller features that coming with this PR:

### Smaller features

1. `law luigid` sub command: The law configuration file can contain sections that synced with the internal luigi config (via naming sections `[luigi_<section>]`), which is a convenience to just maintain a single file. However, when starting the central scheduler with `luigid`, these sections are not considered. The new `law luigid` sub command loads and synchronizes the config and then starts the central scheduler, just like plain `luigid` would do.
2. Interface to declare job resource as luigi's `process_resources` in remote workflows: Remote workflows like `HTCondorWorkflow` can now declare the resources that their jobs claim to the central luigi scheduler (if used). During status polling, these resources are freed eagerly so that new tasks relying on the same resources can start as soon as possible.

### Main feature

So far, htcondor jobs prepared in separate job files, each with their own `queue` command (though, merged into a single submission file for faster interactions). However, since the central job interface also provides *grouped* jobs (such as used by the CMS-CRAB workflow interface), htcondor jobs can actually make use of that feature, too.

The change required a rather large restructuring of how the htcondor itself treats jobs during their creating and - obviously - how the `HTCondorJobFileFactory` creates its outputs.

There is a config - `job::htcondor_job_grouping_submit`, defaulting to `True` - which controls the submission type. Grouping is now the default. Setting this option to `False` will trigger the old behavior.

---

Requires a port to the release_prep branch.