### PR TITLE
Linting the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-<!-- marker-before-logo -->
-
-<p align="center">
+<h1 align="center">
   <a href="https://github.com/riga/law">
     <img src="https://media.githubusercontent.com/media/riga/law/master/assets/logo.png" />
   </a>
-</p>
-
-<!-- marker-after-logo -->
+</h1>
 
 <!-- marker-before-badges -->
 
@@ -37,6 +33,7 @@
 
 > [!NOTE]  
 > This project is currently under development.
+>
 > - Version 1.0.0 will support Python ≥3.7 and is developed in the [release_prep branch](https://github.com/riga/law/tree/release_prep).
 > - There will be a legacy branch with Python 2.7 and ≤3.6 support that, however, won't receive any new features.
 > - The release is targetted for spring 2024.
@@ -57,25 +54,23 @@ Key features:
 
 <!-- marker-after-header -->
 
-
 ## Contents
 
 <!-- marker-before-contents -->
 
 - [First steps](#first-steps)
-   - [Installation and dependencies](#installation-and-dependencies)
-   - [Usage at CERN](#usage-at-cern)
-   - [Overcomplete example config](#overcomplete-example-config)
+  - [Installation and dependencies](#installation-and-dependencies)
+  - [Usage at CERN](#usage-at-cern)
+  - [Overcomplete example config](#overcomplete-example-config)
 - [Projects using law](#projects-using-law)
 - [Examples](#examples)
 - [Further topics](#further-topics)
-   - [Auto completion on the command-line](#auto-completion-on-the-command-line)
+  - [Auto completion on the command-line](#auto-completion-on-the-command-line)
 - [Development](#development)
-   - [Tests](#tests)
-   - [Contributors](#contributors)
+  - [Tests](#tests)
+  - [Contributors](#contributors)
 
 <!-- marker-after-contents -->
-
 
 <!-- marker-before-body -->
 
@@ -101,16 +96,13 @@ If you plan to use remote targets, the (default) implementation also requires [g
 conda install -c conda-forge gfal2 gfal2-util
 ```
 
-
 ### Usage at CERN
 
 See the [wiki](https://github.com/riga/law/wiki/Usage-at-CERN).
 
-
 ### Overcomplete example config
 
 See [law.cfg.example](https://github.com/riga/law/tree/master/law.cfg.example).
-
 
 ## Projects using law
 
@@ -150,7 +142,6 @@ See [law.cfg.example](https://github.com/riga/law/tree/master/law.cfg.example).
 
 If your project uses law but is not yet listed here, feel free to open a pull request or mention your project details in a new [issue](https://github.com/riga/law/issues/new?assignees=riga&labels=docs&template=register-project.md) and it will be added.
 
-
 ## Examples
 
 All examples can be run either in a Jupyter notebook or a dedicated docker container.
@@ -181,18 +172,17 @@ docker run -ti riga/law:example <example_name>
 - [notifications](https://github.com/riga/law/tree/master/examples/notifications): Demonstration of slack and telegram task status notifications..
 - [CMS Single Top Analysis](https://github.com/riga/law_example_CMSSingleTopAnalysis): Simple physics analysis using law.
 
-
 ## Further topics
 
 ### Auto completion on the command-line
 
-**bash**
+#### bash
 
 ```shell
 source "$( law completion )"
 ```
 
-**zsh**
+#### zsh
 
 zsh is able to load and evaluate bash completion scripts via `bashcompinit`.
 In order for `bashcompinit` to work, you should run `compinstall` to enable completion scripts:
@@ -218,12 +208,10 @@ If this is the case, just source the law completion script (which internally ena
 source "$( law completion )"
 ```
 
-
 ## Development
 
 - Source hosted at [GitHub](https://github.com/riga/law)
 - Report issues, questions, feature requests on [GitHub Issues](https://github.com/riga/law/issues)
-
 
 ### Tests
 
@@ -252,7 +240,6 @@ docker run -ti riga/law:<the_tag>
 | CentOS 7    |    3.7 | c7-py37                                   |
 | CentOS 7    |    3.6 | c7-py36, py36 (removed soon)              |
 | CentOS 7    |    2.7 | c7-py27, c7-py2, py27, py2 (removed soon) |
-
 
 ### Contributors
 

--- a/examples/dropbox_targets/README.md
+++ b/examples/dropbox_targets/README.md
@@ -6,7 +6,6 @@ Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.read
 
 There are multiple ways to setup and run this example:
 
-
 #### Before you start
 
 ##### 1. `gfal2`
@@ -16,7 +15,6 @@ Dropbox targets, as well as other remote targets in law, require the [gfal2 libr
 ```shell
 docker run -ti riga/law:example dropbox_targets
 ```
-
 
 ##### 2. Drobbox API credentials
 
@@ -32,7 +30,6 @@ access_token: ...
 ```
 
 `base` can refer to any directory in your Dropbox. All target paths are resolved relative to this directory and cannot access anything above it.
-
 
 #### Play with targets
 
@@ -91,7 +88,6 @@ data_file.exists()
 # => False
 ```
 
-
 #### Upload, download and target formatters
 
 Write some json data into the file. There are multiple methods to do this, so select the one that fits your needs best:
@@ -138,7 +134,6 @@ data_file.load()
 # => {"foo": "bar", "baz": [1, 2, 3]}
 ```
 
-
 #### Localization
 
 Another method is *target localization*. This is especially helpful when dealing with large files that are either produced or required by a different part of your code or another library. Let's assume you want to work with a large numpy array:
@@ -161,7 +156,6 @@ with array_file.localize("w") as tmp:
     # do some stuff with it
     dnn_prediction_into_file(tmp.path)
 ```
-
 
 #### The local cache
 
@@ -192,7 +186,6 @@ array_file.copy_to_local("/local/path", cache=False)
 # => "/local/path"
 ```
 
-
 #### Fancy examples
 
 ##### 1. Multiple Dropboxes
@@ -208,7 +201,6 @@ pred_file.dump(array_file.load()["prediction"])
 ```
 
 The `fs` argument requires either a `DropboxFileSystem` instance, or the name of a section in your config file that is used to build one.
-
 
 ##### 2. File merging
 

--- a/examples/htcondor_at_cern/README.md
+++ b/examples/htcondor_at_cern/README.md
@@ -6,7 +6,6 @@ The actual payload of the tasks is rather trivial. The workflow consists of 26 t
 
 Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.readthedocs.io/en/latest)
 
-
 #### 0. At CERN: copy this example to your user space
 
 ```shell
@@ -15,13 +14,11 @@ cd /examplepath
 cp -r /afs/cern.ch/user/m/mrieger/public/law_sw/law/examples/htcondor_at_cern/* .
 ```
 
-
 #### 1. Source the setup script (just software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your tasks and their parameters (for autocompletion)
 
@@ -41,7 +38,6 @@ module 'analysis.tasks', 2 task(s):
 
 written 2 task(s) to index file '/examplepath/.law/index'
 ```
-
 
 #### 3. Check the status of the `CreateAlphabet` task
 
@@ -67,9 +63,7 @@ print task status with max_depth -1 and target_depth 0
            absent (0/26)
 ```
 
-
 #### 4. Run the `CreateAlphabet` task
-
 
 ```shell
 law run CreateAlphabet --version v1 --CreateChars-transfer-logs --CreateChars-poll-interval 30sec
@@ -80,7 +74,6 @@ The ``CreateChars`` task is a ``HTCondorWorkflow`` by default, but it is also ab
 This should take only a few minutes to process, depending on the job queue.
 
 By default, this example uses a local scheduler, which - by definition - offers no visualization tools in the browser. If you want to see how the task tree is built and subsequently run, run ``luigid`` in a second terminal. This will start a central scheduler at *localhost:8082* (the default address). To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
-
 
 #### 5. Check the status again
 
@@ -106,14 +99,12 @@ print task status with max_depth -1 and target_depth 0
            existent (26/26)
 ```
 
-
 #### 6. Look at the results
 
 ```shell
 cd data
 ls */v1/
 ```
-
 
 #### 7. Cleanup the results
 

--- a/examples/htcondor_at_naf/README.md
+++ b/examples/htcondor_at_naf/README.md
@@ -7,7 +7,6 @@ The workflow consists of 26 tasks which convert an integer between 97 and 122 (a
 
 Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.readthedocs.io/en/latest)
 
-
 #### 0. At NAF: copy this example to your user space
 
 ```shell
@@ -16,13 +15,11 @@ cd /examplepath
 cp -r /afs/desy.de/user/r/riegerma/public/law_sw/law/examples/htcondor_at_naf/* .
 ```
 
-
 #### 1. Source the setup script (just software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your tasks and their parameters (for autocompletion)
 
@@ -42,7 +39,6 @@ module 'analysis.tasks', 2 task(s):
 
 written 2 task(s) to index file '/examplepath/.law/index'
 ```
-
 
 #### 3. Check the status of the `CreateAlphabet` task
 
@@ -69,9 +65,7 @@ print task status with max_depth -1 and target_depth 0
            absent (0/26)
 ```
 
-
 #### 4. Run the `CreateAlphabet` task
-
 
 ```shell
 law run CreateAlphabet --version v1 --CreateChars-transfer-logs --CreateChars-poll-interval 30sec
@@ -86,7 +80,6 @@ By default, this example uses a local scheduler, which - by definition - offers 
 If you want to see how the task tree is built and subsequently run, run ``luigid`` in a second terminal.
 This will start a central scheduler at *localhost:8082* (the default address).
 To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
-
 
 #### 5. Check the status again
 
@@ -112,14 +105,12 @@ print task status with max_depth -1 and target_depth 0
            existent (26/26)
 ```
 
-
 #### 6. Look at the results
 
 ```shell
 cd data
 ls */v1/
 ```
-
 
 #### 7. Cleanup the results
 

--- a/examples/htcondor_at_vispa/README.md
+++ b/examples/htcondor_at_vispa/README.md
@@ -6,7 +6,6 @@ The actual payload of the tasks is rather trivial. The workflow consists of 26 t
 
 Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.readthedocs.io/en/latest)
 
-
 #### 0. At VISPA: copy this example to your user space
 
 ```shell
@@ -15,13 +14,11 @@ cd /examplepath
 cp -r /home/Marcel/public/law_sw/law/examples/htcondor_at_vispa/* .
 ```
 
-
 #### 1. Source the setup script (just software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your tasks and their parameters (for autocompletion)
 
@@ -41,7 +38,6 @@ module 'analysis.tasks', 2 task(s):
 
 written 2 task(s) to index file '/examplepath/.law/index'
 ```
-
 
 #### 3. Check the status of the `CreateAlphabet` task
 
@@ -67,9 +63,7 @@ print task status with max_depth -1 and target_depth 0
            absent (0/26)
 ```
 
-
 #### 4. Run the `CreateAlphabet` task
-
 
 ```shell
 law run CreateAlphabet --version v1 --CreateChars-transfer-logs --CreateChars-poll-interval 30sec
@@ -80,7 +74,6 @@ The ``CreateChars`` task is a ``HTCondorWorkflow`` by default, but it is also ab
 This should take only a few minutes to process, depending on the job queue.
 
 By default, this example uses a local scheduler, which - by definition - offers no visualization tools in the browser. If you want to see how the task tree is built and subsequently run, run ``luigid`` in a second terminal. This will start a central scheduler at *localhost:8082* (the default address). To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
-
 
 #### 5. Check the status again
 
@@ -106,14 +99,12 @@ print task status with max_depth -1 and target_depth 0
            existent (26/26)
 ```
 
-
 #### 6. Look at the results
 
 ```shell
 cd data
 ls */v1/
 ```
-
 
 #### 7. Cleanup the results
 

--- a/examples/lsf_at_cern/README.md
+++ b/examples/lsf_at_cern/README.md
@@ -6,7 +6,6 @@ The actual payload of the tasks is rather trivial. The workflow consists of 26 t
 
 Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.readthedocs.io/en/latest)
 
-
 #### 0. At CERN: copy this example to your user space
 
 ```shell
@@ -15,13 +14,11 @@ cd /examplepath
 cp -r /afs/cern.ch/user/m/mrieger/public/law_sw/law/examples/lsf_at_cern/* .
 ```
 
-
 #### 1. Source the setup script (just software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your tasks and their parameters (for autocompletion)
 
@@ -41,7 +38,6 @@ module 'analysis.tasks', 2 task(s):
 
 written 2 task(s) to index file '/examplepath/.law/index'
 ```
-
 
 #### 3. Check the status of the `CreateAlphabet` task
 
@@ -67,9 +63,7 @@ print task status with max_depth -1 and target_depth 0
 |   |     -> absent (0/26)
 ```
 
-
 #### 4. Run the `CreateAlphabet` task
-
 
 ```shell
 law run CreateAlphabet --version v1 --CreateChars-transfer-logs --CreateChars-poll-interval 30sec
@@ -80,7 +74,6 @@ The ``CreateChars`` task is a ``LSFWorkflow`` by default, but it is also able to
 This should take only a few minutes to process, depending on the job queue at CERN.
 
 By default, this example uses a local scheduler, which - by definition - offers no visualization tools in the browser. If you want to see how the task tree is built and subsequently run, run ``luigid`` in a second terminal. This will start a central scheduler at *localhost:8082* (the default address). To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
-
 
 #### 5. Check the status again
 
@@ -106,14 +99,12 @@ print task status with max_depth -1 and target_depth 0
 |   |     -> existent (26/26)
 ```
 
-
 #### 6. Look at the results
 
 ```shell
 cd data
 ls */v1/
 ```
-
 
 #### 7. Cleanup the results
 

--- a/examples/notifications/README.md
+++ b/examples/notifications/README.md
@@ -9,29 +9,27 @@ There are multiple ways to setup and run this example:
 1. Docker: `docker run -ti riga/law:example loremipsum`
 2. Local: `source setup.sh`
 
-
 ## Prerequisites
 
 ### Install Python clients
 
 This step is not needed when running the example in docker.
 
-```
+```bash
 pip install slackclient
 ```
 
 and/or
 
-```
+```bash
 pip install python-telegram-bot
 ```
-
 
 ### API tokens
 
 Before you start, you need to obtain Slack and/or Telegram API tokens and add them to the `law.cfg` file, located in this example. The config sections should look like this:
 
-```
+```ini
 [notifications]
 
 slack_token: ...
@@ -43,7 +41,6 @@ telegram_chat: ...
 telegram_mention_user: ... (optional, a telegram user name to @mention in the notification)
 ```
 
-
 ##### Slack
 
 1. Visit [api.slack.com/apps/new](https://api.slack.com/apps/new). Follow the instructions, enter the name of your app and select your workspace.
@@ -54,7 +51,6 @@ telegram_mention_user: ... (optional, a telegram user name to @mention in the no
 6. Go to your Slack window and start a channel with your newly created app.
 7. Right-click on the channel in the sidebar and copy the link which contains the channel ID in the last URL fragment.
 
-
 ##### Telegram
 
 1. Start a chat with the Telegram admin bot "@BotFather".
@@ -62,18 +58,15 @@ telegram_mention_user: ... (optional, a telegram user name to @mention in the no
 3. Start a new chat with your newly created bot ("@<bot_name>") and send an arbitrary message. The content is not important.
 4. Visit [api.telegram.org/bot\<bot_token\>/getUpdates](https://api.telegram.org/bot<bot_token>/getUpdates). It will show recent messages with JSON encoding. Your chat ID is shown in `result[0].chat.id`.
 
-
 ## Run the example task
 
 After adding your API tokens to the `law.cfg` file, you can run the example task `MyTask`. The task has two bool parameters, `--notify-slack` and `--notify-telegram`. An additional parameter, `--fail`, can be added to simulate notifications sent by failed tasks.
-
 
 #### 1. Source the setup script (just sets up software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your the tasks and their parameters (for autocompletion)
 
@@ -93,9 +86,7 @@ module 'tasks', 1 task(s):
 written 1 task(s) to index file '/examplepath/.law/index'
 ```
 
-
 #### 3. Run the task with enabled notifications
-
 
 ```shell
 law run MyTask --notify-slack
@@ -106,7 +97,6 @@ This should take about 2 seconds before a slack notification is sent. For telegr
 The notification looks like this:
 
 ![law slack notification](https://www.dropbox.com/s/eic7zfdvf83meku/law_slack_notification.png?dl=0&raw=1 "law slack notification")
-
 
 You can add `--fail` to the command line to sent a failure notification:
 

--- a/examples/parallel_optimization/README.md
+++ b/examples/parallel_optimization/README.md
@@ -13,20 +13,17 @@ There are multiple ways to setup and run this example:
 1. Docker: `docker run -ti riga/law:example loremipsum`
 2. Local: `source setup.sh`
 
-
 #### 1. Install dependencies for this example
 
 ```shell
 pip install luigi scikit-optimize matplotlib
 ```
 
-
 #### 2. Source the setup script (just sets up some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 3. Let law index your the tasks and their parameters (for autocompletion)
 
@@ -48,7 +45,6 @@ module 'tasks', 3 task(s):
 written 3 task(s) to index file '/examplepath/.law/index'
 ```
 
-
 #### 4. Check the status of the OptimizerPlot task
 
 ```shell
@@ -67,7 +63,6 @@ print task status with max_depth -1 and target_depth 0
 
 The `-1` value tells law to recursively check the task status. Given a positive number, law stops at that level. The task itself has a depth of `0`.
 
-
 #### 5. Run the OptimizerPlot task
 
 ```shell
@@ -78,7 +73,6 @@ This should take a minute to process.
 You can see the plots being created after each optimization step at `data/OptimizerPlot`.
 
 By default, this example uses a local scheduler, which - by definition - offers no visualization tools in the browser. If you want to see how the task tree is built and subsequently run, run ``luigid`` in a second terminal. This will start a central scheduler at *localhost:8082* (the default address). To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
-
 
 #### 6. Check the status again
 
@@ -95,7 +89,6 @@ print task status with max_depth -1 and target_depth 0
 |   - check TargetCollection(len=10, threshold=1.0)
 |     -> existent (10/10)
 ```
-
 
 #### 7. Look at the results
 

--- a/examples/sequential_htcondor_at_cern/README.md
+++ b/examples/sequential_htcondor_at_cern/README.md
@@ -16,7 +16,6 @@ A single, final task collects the partial results in the end and writes all char
 
 The dependency structure is visualized in the following graph.
 
-
 ```mermaid
 graph TD
     CFA(CreateFullAlphabet)
@@ -55,7 +54,6 @@ As soon as a single `CreateChars` chunk (of five) workflow is finished, a dedica
 
 Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.readthedocs.io/en/latest)
 
-
 #### 0. At CERN: copy this example to your user space
 
 ```shell
@@ -64,13 +62,11 @@ cd /examplepath
 cp -r /afs/cern.ch/user/m/mrieger/public/law_sw/law/examples/sequential_htcondor_at_cern/* .
 ```
 
-
 #### 1. Source the setup script (just software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your tasks and their parameters (for autocompletion)
 
@@ -91,7 +87,6 @@ module 'analysis.tasks', 3 task(s):
 
 written 3 task(s) to index file '/examplepath/.law/index'
 ```
-
 
 #### 3. Check the status a `CreatePartialAlphabet` task
 
@@ -158,7 +153,6 @@ print task status with max_depth -1 and target_depth 0
 
 In any case, no tasks ran so far, so no output target should exist yet.
 
-
 #### 4. Check the status of the `CreateFullAlphabet` task
 
 This task triggers the six `CreatePartialAlphabet` tasks which in turn require all 26 `CreateChars` tasks.
@@ -224,11 +218,9 @@ print task status with max_depth 1 and target_depth 0
 
 As you can see, there is a total of six tasks required (`ceil(26 / 5)`).
 
-
 #### 5. Run the `CreateFullAlphabet` task
 
 As we want to see the eager submission structure in action, we pick six six parallel processes to run (``--workers 6``) which allows starting the six `CreatePartialAlphabet` tasks (that only perform job status polling on your local machine) with maximum concurrency.
-
 
 ```shell
 law run CreateFullAlphabet --version v1 --workers 6
@@ -243,14 +235,12 @@ If you want to see how the task tree is built and subsequently run, run ``luigid
 This will start a central scheduler at *localhost:8082* (the default address).
 To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
 
-
 #### 6. Look at the results
 
 ```shell
 cd data
 ls */v1/
 ```
-
 
 #### 7. Cleanup the results
 

--- a/examples/slurm_at_maxwell/README.md
+++ b/examples/slurm_at_maxwell/README.md
@@ -8,7 +8,6 @@ A single task collects the results in the end and writes all characters into a t
 
 Resources: [luigi](http://luigi.readthedocs.io/en/stable), [law](http://law.readthedocs.io/en/latest)
 
-
 #### 0. At Maxwell: copy this example to your user space
 
 ```shell
@@ -17,13 +16,11 @@ cd /examplepath
 cp -r /afs/desy.de/user/r/riegerma/public/law_sw/law/examples/slurm_at_maxwell/* .
 ```
 
-
 #### 1. Source the setup script (just software and some variables)
 
 ```shell
 source setup.sh
 ```
-
 
 #### 2. Let law index your tasks and their parameters (for autocompletion)
 
@@ -43,7 +40,6 @@ module 'analysis.tasks', 2 task(s):
 
 written 2 task(s) to index file '/examplepath/.law/index'
 ```
-
 
 #### 3. Check the status of the `CreateAlphabet` task
 
@@ -69,9 +65,7 @@ print task status with max_depth -1 and target_depth 0
            absent (0/26)
 ```
 
-
 #### 4. Run the `CreateAlphabet` task
-
 
 ```shell
 law run CreateAlphabet --version v1 --CreateChars-transfer-logs --CreateChars-poll-interval 30sec
@@ -86,7 +80,6 @@ By default, this example uses a local scheduler, which - by definition - offers 
 If you want to see how the task tree is built and subsequently run, run ``luigid`` in a second terminal.
 This will start a central scheduler at *localhost:8082* (the default address).
 To inform tasks (or rather *workers*) about the scheduler, either add ``--local-scheduler False`` to the ``law run`` command, or set the ``local-scheduler`` value in the ``[luigi_core]`` config section in the ``law.cfg`` file to ``False``.
-
 
 #### 5. Check the status again
 
@@ -112,14 +105,12 @@ print task status with max_depth -1 and target_depth 0
            existent (26/26)
 ```
 
-
 #### 6. Look at the results
 
 ```shell
 cd data
 ls */v1/
 ```
-
 
 #### 7. Cleanup the results
 

--- a/examples/workflow_parameters/README.md
+++ b/examples/workflow_parameters/README.md
@@ -4,7 +4,6 @@ This short example demonstrates the usage of so-called `WorkflowParameter`s.
 
 To understand this concept, make sure you've read the general [documentation on workflows](https://law.readthedocs.io/en/latest/workflows.html), especially regarding how the `branch_map` of a *workflow* defines which *branch* tasks it will run.
 
-
 ## Recap: Workflows
 
 In short, if we consider the following example,
@@ -36,7 +35,7 @@ the dictionary returned by `create_branch_map` defines `MyWorkflow`'s branches.
 If we were to execute a single branch, say `0`, we could run
 
 ```shell
-$ law run MyWorkflow --branch 0
+law run MyWorkflow --branch 0
 ```
 
 and the above task would run with `self.branch = 0` and, according to the branch map, `self.branch_data = {"option_a": "foo", "option_b": 123}`.
@@ -44,15 +43,14 @@ The latter is usually used to control the task's behavior in `run()`, `output()`
 
 To run multiple branches simultaneously, you would usually
 
-  - omit the `--branch` parameter or set it to `--branch -1` to trigger the *workflow* instead of a specific branch, **and optionally**
-  - add `--branches SELECTION` to select a subset of possible branches (`SELECTION` can be a comma-separated list of branches or pythonic slices, e.g. `0,3,5:9`).
+- omit the `--branch` parameter or set it to `--branch -1` to trigger the *workflow* instead of a specific branch, **and optionally**
+- add `--branches SELECTION` to select a subset of possible branches (`SELECTION` can be a comma-separated list of branches or pythonic slices, e.g. `0,3,5:9`).
 
 The workflow then determines which branches it needs to run and handles their execution depending on its workflow type (`law.LocalWorkflow` runs them locally, whereas remote workflows such as `law.htcondor.HTCondorWorlflow` submit them as HTCondor jobs).
 
 This mechanism is generic, but in case you are dealing with complex branch maps, triggering a specific single branch or a specific subset of branches requires you to know their branch values which you then use on the command line with either `--branch` or `--branches`.
 
 **`WorkflowParameter`s provide a way to make this branch lookup more convenient**❗️
-
 
 ## Dynamic branch lookup: `WorkflowParameter`
 
@@ -103,7 +101,7 @@ This is necessary since the automatic lookup of branches based on the values of 
 
 As a result, parameters can be defined verbosely on the command line, translate to branch values, and configure which branches are run by the workflow:
 
-  - `--option-a foo --option-b 123` → finds `branch=0` (but for this, you probably wouldn't need a workflow in the first place)
-  - `--option-a foo` → finds `branches=[0, 2]` and runs them as a workflow
-  - `--option-b 456` → finds `branches=[1, 2]` and runs them as a workflow
-  - `--option-b 123` → finds `branches=[0]` and runs it in a workflow
+- `--option-a foo --option-b 123` → finds `branch=0` (but for this, you probably wouldn't need a workflow in the first place)
+- `--option-a foo` → finds `branches=[0, 2]` and runs them as a workflow
+- `--option-b 456` → finds `branches=[1, 2]` and runs them as a workflow
+- `--option-b 123` → finds `branches=[0]` and runs it in a workflow

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -11,7 +11,6 @@ There are multiple ways to setup and run this example:
 1. Docker: `docker run -ti riga/law:example loremipsum`
 2. Local: `source setup.sh`
 
-
 #### 1. Let law index your the tasks and their parameters (for autocompletion)
 
 ```shell
@@ -30,7 +29,6 @@ module 'analysis.tasks', 2 task(s):
 
 written 2 task(s) to index file '/law/examples/workflows/.law/index'
 ```
-
 
 #### 2. Check the status of the CreateAlphabet task
 
@@ -52,9 +50,7 @@ print task status with max_depth -1 and target_depth 0
 |   |     -> absent (0/26)
 ```
 
-
 #### 3. Run the CreateAlphabet task
-
 
 ```shell
 law run CreateAlphabet
@@ -69,7 +65,6 @@ The task tree should look like this in the scheduler app:
 ![Workflow graph](https://www.dropbox.com/s/o2lcz42u4y6ncvg/law_workflows.png?raw=1 "Workflow graph")
 
 Also, you might want to add the ``--slow`` parameter to make the tasks somewhat slower in order to see the actual progress in the scheduler (this is of course not a feature of law, but only implemented by the tasks in this example ;) ).
-
 
 #### 3. Check the status again
 
@@ -94,14 +89,12 @@ print task status with max_depth 1 and target_depth 0
 To see the status of the targets in the collection, i.e., the grouped outputs of the branch tasks,
 set the target depth via `--print-status 1,1`.
 
-
 #### 4. Look at the results
 
 ```shell
 cd data
 ls
 ```
-
 
 #### 5. Cleanup the results
 


### PR DESCRIPTION
Minor linting fixes in the README.md files across `law`.
`pymarkdown` requires still some changes for all `.md` files under `.github/ISSUE_TEMPLATE/`, which are not changed in this pull request, since I am not sure if it is wanted.