### PR TITLE
Adds pandas `contrib` module

### DIFF
--- a/law/contrib/pandas/__init__.py
+++ b/law/contrib/pandas/__init__.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+# flake8: noqa
+
+"""
+Pandas contrib functionality.
+"""
+
+__all__ = ["DataFrameFormatter"]
+
+
+# provisioning imports
+from law.contrib.pandas.formatter import DataFrameFormatter

--- a/law/contrib/pandas/formatter.py
+++ b/law/contrib/pandas/formatter.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+
+"""
+Pandas target formatters.
+"""
+
+__all__ = ["DataFrameFormatter"]
+
+
+import pathlib
+from law.target.formatter import Formatter, PickleFormatter
+from law.target.file import get_path
+from law.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class DataFrameFormatter(Formatter):
+
+    name = "dataframe"
+
+    @classmethod
+    def accepts(cls, path, mode):
+        # still missing: excel, html, xml, latex, feather, orc, sql, stata, markdown, ...
+        return get_path(path).endswith(
+            (".csv", ".json", ".parquet", ".h5", ".hdf5", ".pickle", ".pkl")
+        )
+
+    @classmethod
+    def load(cls, path, *args, **kwargs):
+        path = get_path(path)
+        if path.endswith(".csv"):
+            import pandas  # fmt: skip
+            return pandas.read_csv(path, *args, **kwargs)
+
+        if path.endswith(".json"):
+            import pandas  # fmt: skip
+            return pandas.read_json(path, *args, **kwargs)
+
+        if path.endswith(".parquet"):
+            import pandas  # fmt: skip
+            return pandas.read_parquet(path, *args, **kwargs)
+
+        if path.endswith((".h5", ".hdf5")):
+            import pandas  # fmt: skip
+            return pandas.read_hdf(path, *args, **kwargs)
+
+        if path.endswith((".pickle", ".pkl")):
+            import pandas  # fmt: skip
+            return pandas.read_pickle(path, *args, **kwargs)
+
+        suffix = pathlib.Path(path).suffix
+        raise NotImplementedError(f"Suffix \"{suffix}\" not implemented in DataFrameFormatter")
+
+    @classmethod
+    def dump(cls, path, obj, *args, **kwargs):
+        path = get_path(path)
+
+        if path.endswith(".csv"):
+            return obj.to_csv(path, *args, **kwargs)
+
+        if path.endswith(".json"):
+            return obj.to_json(path, *args, **kwargs)
+
+        if path.endswith(".parquet"):
+            return obj.to_parquet(path, *args, **kwargs)
+
+        if path.endswith((".h5", ".hdf5")):
+            return obj.to_hdf(path, *args, **kwargs)
+
+        if path.endswith((".pickle", ".pkl")):
+            return obj.to_pickle(path, *args, **kwargs)
+
+        suffix = pathlib.Path(path).suffix
+        raise NotImplementedError(f"Suffix \"{suffix}\" not implemented in DataFrameFormatter")

--- a/law/contrib/pandas/formatter.py
+++ b/law/contrib/pandas/formatter.py
@@ -23,9 +23,8 @@ class DataFrameFormatter(Formatter):
     @classmethod
     def accepts(cls, path, mode):
         # still missing: excel, html, xml, latex, feather, orc, sql, stata, markdown, ...
-        return get_path(path).endswith(
-            (".csv", ".json", ".parquet", ".h5", ".hdf5", ".pickle", ".pkl")
-        )
+        suffixes = (".csv", ".json", ".parquet", ".h5", ".hdf5", ".pickle", ".pkl")
+        return get_path(path).endswith(suffixes)
 
     @classmethod
     def load(cls, path, *args, **kwargs):
@@ -52,7 +51,7 @@ class DataFrameFormatter(Formatter):
 
         suffix = pathlib.Path(path).suffix
         raise NotImplementedError(
-            f'Suffix "{suffix}" not implemented in DataFrameFormatter'
+            f'Suffix "{suffix}" not implemented in DataFrameFormatter',
         )
 
     @classmethod
@@ -76,5 +75,5 @@ class DataFrameFormatter(Formatter):
 
         suffix = pathlib.Path(path).suffix
         raise NotImplementedError(
-            f'Suffix "{suffix}" not implemented in DataFrameFormatter'
+            f'Suffix "{suffix}" not implemented in DataFrameFormatter',
         )

--- a/law/contrib/pandas/formatter.py
+++ b/law/contrib/pandas/formatter.py
@@ -51,7 +51,9 @@ class DataFrameFormatter(Formatter):
             return pandas.read_pickle(path, *args, **kwargs)
 
         suffix = pathlib.Path(path).suffix
-        raise NotImplementedError(f"Suffix \"{suffix}\" not implemented in DataFrameFormatter")
+        raise NotImplementedError(
+            f'Suffix "{suffix}" not implemented in DataFrameFormatter'
+        )
 
     @classmethod
     def dump(cls, path, obj, *args, **kwargs):
@@ -73,4 +75,6 @@ class DataFrameFormatter(Formatter):
             return obj.to_pickle(path, *args, **kwargs)
 
         suffix = pathlib.Path(path).suffix
-        raise NotImplementedError(f"Suffix \"{suffix}\" not implemented in DataFrameFormatter")
+        raise NotImplementedError(
+            f'Suffix "{suffix}" not implemented in DataFrameFormatter'
+        )

--- a/law/contrib/pandas/formatter.py
+++ b/law/contrib/pandas/formatter.py
@@ -8,7 +8,7 @@ __all__ = ["DataFrameFormatter"]
 
 
 import pathlib
-from law.target.formatter import Formatter, PickleFormatter
+from law.target.formatter import Formatter
 from law.target.file import get_path
 from law.logger import get_logger
 


### PR DESCRIPTION
These changes add the pandas `contrib` module.
For now this `contrib` module includes the `DataFrameFormatter`.
The `DataFrameFormatter` can be used to read and write instances of `pandas.DataFrame`.