### PR TITLE
Parse `forward_law` as bool in `Singularity.Sandbox`

### DIFF
--- a/law/contrib/singularity/sandbox.py
+++ b/law/contrib/singularity/sandbox.py
@@ -179,7 +179,7 @@ class SingularitySandbox(Sandbox):
         if callable(forward_law_cb):
             forward_law = forward_law_cb()
         else:
-            forward_law = cfg.get_expanded(cfg_section, "forward_law")
+            forward_law = cfg.get_expanded_bool(cfg_section, "forward_law")
 
         # environment variables to set
         env = self._get_env()


### PR DESCRIPTION
The [`forward_law`](https://github.com/riga/law/blob/master/law/contrib/singularity/sandbox.py#L182) variable was getting parsed as a string instead of boolean leading to [this check](https://github.com/riga/law/blob/master/law/contrib/singularity/sandbox.py#L190) failing