### PR TITLE
Speedup NestedSiblinFileCollection when possible

### DIFF
--- a/law/target/collection.py
+++ b/law/target/collection.py
@@ -439,39 +439,18 @@ class NestedSiblingFileCollection(SiblingFileCollectionBase):
         if basenames is None:
             basenames = self._get_basenames()
 
-        # helper to check for existence
-        def exists(t, _basenames):
-            if optional_existing is not None and t.optional:
-                return optional_existing
-            if isinstance(t, SiblingFileCollectionBase):
-                return t._exists_fwd(
-                    basenames=_basenames,
-                    optional_existing=optional_existing,
-                )
-            if isinstance(t, TargetCollection):
-                return all(exists(_t for _t in flatten_collections(t)))
-            return t.basename in _basenames
-
-        # loop and yield
-        if keys:
-            for key, targets in self._iter_flat():
-                state = all(exists(t, basenames[self._flat_target_collections[t]]) for t in targets)
-                if state is existing:
-                    if unpack:
-                        targets = self.targets[key]
-                    yield (key, targets) if keys else targets
-        else:  # heavy speedup
-            for collection in self.collections:
-                collection_iterator = collection._iter_state(
-                    existing=existing,
-                    optional_existing=optional_existing,
-                    basenames=basenames[collection],
-                    keys=keys,
-                    unpack=unpack
-                )
-                for element in collection_iterator:
-                    yield element
-
+        # reuse state iteration of wrapped collections
+        for coll in self.collections:
+            iter_kwargs = {
+                "existing": existing,
+                "optional_existing": optional_existing,
+                "keys": keys,
+                "unpack": unpack,
+            }
+            if isinstance(coll, SiblingFileCollectionBase) and coll in basenames:
+                iter_kwargs["basenames"] = basenames[coll]
+            for obj in coll._iter_state(**iter_kwargs):
+                yield obj 
 
     def _exists_fwd(self, **kwargs):
         fwd = [("basenames", "basenames_dict"), ("optional_existing", "optional_existing")]


### PR DESCRIPTION
In my tests, this gives a speed-up of a factor of more than 60 for a nested sibling file collection of 4000 files.
```console
$ python test.py
NestedSiblingFileCollection(len=4000, threshold=1.0, collections=4)
True
Total: 62.249094 seconds

$ python test.py
NestedSiblingFileCollection(len=4000, threshold=1.0, collections=4)
True
Total: 0.858903 seconds
```

Testing script:
```python
import law
from law import NestedSiblingFileCollection
import time

law.contrib.load("wlcg")


targets = []
for j in range(4):
    for i in range(1000):
        i += j*1000
        targets.append(law.wlcg.WLCGFileTarget(f"HerwigRun/Dijets_LO/NPoff/{j}/Dijets_LOjob{i}.tar.bz2"))

collection = NestedSiblingFileCollection(targets)
print(collection)
start = time.time()
print(collection.complete())
end = time.time()
print(f"Total: {end-start:2f} seconds")
```
Testing law.cfg:
```
[target]
default_wlcg_fs = wlcg_fs

[wlcg_fs]
base = root://cmsxrootd-redirectors.gridka.de:1094//store/user/mhorzela/HerwigMC
```

I think this can be implemented way cleaner, but I did not come up with a good idea on how to get the correct keys otherwise. Maybe @riga knows a more general way for also achieving this speed-up, when the keys are required.