### PR TITLE
Fix wrong keys in Collections within NestedFileSiblingCollections

### DIFF
--- a/law/target/collection.py
+++ b/law/target/collection.py
@@ -404,11 +404,18 @@ class NestedSiblingFileCollection(SiblingFileCollectionBase):
         self.collections = []
         self._flat_target_collections = {}
         grouped_targets = {}
-        for t in flatten_collections(self._flat_target_list):
-            grouped_targets.setdefault(t.parent.uri(), []).append(t)
+        for key, target in six.iteritems(self._flat_targets):
+            target = flatten_collections(target)
+            if isinstance(target, list):
+                if len(target) > 1:
+                    raise NotImplementedError(
+                        "Only passing single file targets to NestedSiblingFileCollection is supported."
+                    )
+                target = target[0]
+            grouped_targets.setdefault(target.parent.uri(), []).append((key, target))
         for targets in grouped_targets.values():
             # create and store the collection
-            collection = SiblingFileCollection(targets)
+            collection = SiblingFileCollection(dict(targets))
             self.collections.append(collection)
             # remember the collection per target
             for t in targets:


### PR DESCRIPTION
See title.
As soon as multiple SiblingCollections are used within a NestedSiblingFileCollection, the keys are not copied. This results in wrong behaviour, e.g. when printing the status of a workflow for each single file.