### PR TITLE
Heavy performance improvment when starting large RemoteWorkflows

### DIFF
--- a/law/workflow/remote.py
+++ b/law/workflow/remote.py
@@ -543,6 +543,12 @@ class BaseRemoteWorkflowProxy(BaseWorkflowProxy):
             job_resources = {}
             get_job_resources = self._get_task_attribute("job_resources")
 
+            outputs = self.output()
+            if len(self._initially_existing_branches) == 0 and "collection" in outputs:
+                collection = outputs["collection"]
+                _, keys = collection.count(keys=True)  # only existing keys
+                self._initially_existing_branches = keys
+
             branch_chunks = iter_chunks(task.branch_map.keys(), task.tasks_per_job)
             for job_num, branches in enumerate(branch_chunks, 1):
                 if self._can_skip_job(job_num, branches):


### PR DESCRIPTION
Currently, the time to launch a Remote Workflow or HTCondorWorkflow (with (Nested)SiblingFileCollection as output cls) scales exponentially with the number of files, as the cache for already existing branches is only set when the run method is invoked in https://github.com/riga/law/blob/499d406ff29d3840daf6f2186905fbeca98f485b/law/workflow/remote.py#L658

Now I already fill the cache (using the faster versions of (Nested)SiblingFileCollections) during the process_resources call when scheduling which branches to run.

Queing 1k Jobs just with the luigi scheduler (no submission, as this task is already complete):
Without my patch 48s:
```cmd
law run SherpaRun --campaign LHC-NLO-ZplusJet --mc-setting NPoff  1000  1.0    36.80s user 1.12s system 77% cpu 48.793 total
```
With the patch 11s:
```cmd
law run SherpaRun --campaign LHC-NLO-ZplusJet --mc-setting NPoff  1000  1.0    10.34s user 0.72s system 94% cpu 11.695 total
```

I'm also testing this for 10k jobs at the moment, but I cancelled the process after 17 minutes. With my patch, it finished in 1:30 minutes.