### PR TITLE
Create TFile using Open instead of the TFile constructor

### DIFF
--- a/law/contrib/root/formatter.py
+++ b/law/contrib/root/formatter.py
@@ -36,7 +36,7 @@ class GuardedTFile(object):
         if len(args) == 1 and isinstance(args[0], ROOT.TFile) and not kwargs:
             self._guarded_tfile = args[0]
         elif args or kwargs:
-            self._guarded_tfile = ROOT.TFile(*args, **kwargs)
+            self._guarded_tfile = ROOT.TFile.Open(*args, **kwargs)
 
     def __enter__(self):
         return self._guarded_tfile


### PR DESCRIPTION
Hi @riga , I found out that `ROOT.TFile` fails when opening files on the grid, but `ROOT.TFile.Open` doesn't. I've replaced it here, but I'm not sure it this change has any other implications.