### PR TITLE
Fix globbing on LocalDirectoryTargets

### DIFF
--- a/law/target/local.py
+++ b/law/target/local.py
@@ -228,9 +228,9 @@ class LocalFileSystem(FileSystem, shims.LocalFileSystem):
             search_dirs.extend((os.path.join(search_dir, d), depth + 1) for d in dirs)
 
     def glob(self, pattern, cwd=None, **kwargs):
-        pattern = self.abspath(pattern)
-
-        if cwd is not None:
+        if cwd is None:
+            pattern = self.abspath(pattern)
+        else:
             cwd = self.abspath(cwd)
             pattern = os.path.join(cwd, pattern)
 


### PR DESCRIPTION
When using the glob function on a LocalDirectpryTarget, I expect it to use the directory as a base when globbing. This is not the case. Globs are defaulting to the root directory `/`. This PR changes this behaviour.

Testing:
```bash
mkdir -p /tmp/law_glob
touch /tmp/law_glob/foo.txt
touch /tmp/law_glob/bar.json
```
Old:
```python
>>> import law
>>> test_dir = law.LocalDirectoryTarget("/tmp/law_glob")
>>> test_dir.glob("*")
['../../boot', '../../dev', '../../home', '../../proc', '../../run', '../../sys', '..', '../../etc', '../../root', '../../var', '../../usr', '../../bin', '../../sbin', '../../lib', '../../lib64', '../../afs', '../../media', '../../mnt', '../../opt', '../../srv', '../../ceph', '../../storage', '../../web', '../../work', '../../local', '../../misc', '../../net', '../../ssd_test', '../../cvmfs']
>>> test_dir.glob("*.txt")
[]
```
New:
```python
>>> import law
>>> test_dir = law.LocalDirectoryTarget("/tmp/law_glob")
>>> test_dir.glob("*")
['foo.txt', 'bar.json']
>>> test_dir.glob("*.txt")
['foo.txt']
```