### PR TITLE
Fix copy validation and permission handling for RemoteFileSystem with a local file:// base

### DIFF
--- a/law/target/remote/base.py
+++ b/law/target/remote/base.py
@@ -356,8 +356,7 @@ class RemoteFileSystem(FileSystem):
         # actual copy
         src_uri, dst_uri = self.file_interface.filecopy(src, dst, **kwargs)
 
-        # dst is base-relative, so use dst_uri instead when dst_fs is local_fs, which has its own,
-        # unrelated base
+        # dst is base-relative, so use dst_uri instead when dst_fs is local_fs
         dst_is_local = self.is_local(dst_uri)
         dst_fs = self.local_fs if dst_is_local else self
         resolved_dst = dst_uri if dst_is_local else dst
@@ -367,7 +366,7 @@ class RemoteFileSystem(FileSystem):
             if not dst_fs.exists(resolved_dst):
                 raise Exception("validation failed after copying {} to {}".format(src_uri, dst_uri))
 
-        # handle permissions; default_file_perm belongs to self, not dst_fs
+        # handle permissions
         if perm is None:
             perm = self.default_file_perm
         dst_fs.chmod(resolved_dst, perm)

--- a/law/target/remote/base.py
+++ b/law/target/remote/base.py
@@ -356,10 +356,15 @@ class RemoteFileSystem(FileSystem):
         # actual copy
         src_uri, dst_uri = self.file_interface.filecopy(src, dst, **kwargs)
 
+        # dst is base-relative, so use dst_uri instead when dst_fs is local_fs, which has its own,
+        # unrelated base
+        dst_is_local = self.is_local(dst_uri)
+        dst_fs = self.local_fs if dst_is_local else self
+        resolved_dst = dst_uri if dst_is_local else dst
+
         # copy validation
-        dst_fs = self.local_fs if self.is_local(dst_uri) else self
         if validate:
-            if not dst_fs.exists(dst):
+            if not dst_fs.exists(resolved_dst):
                 raise Exception("validation failed after copying {} to {}".format(src_uri, dst_uri))
 
         # handle permissions

--- a/law/target/remote/base.py
+++ b/law/target/remote/base.py
@@ -367,10 +367,10 @@ class RemoteFileSystem(FileSystem):
             if not dst_fs.exists(resolved_dst):
                 raise Exception("validation failed after copying {} to {}".format(src_uri, dst_uri))
 
-        # handle permissions
+        # handle permissions; default_file_perm belongs to self, not dst_fs
         if perm is None:
-            perm = dst_fs.default_file_perm
-        dst_fs.chmod(dst, perm)
+            perm = self.default_file_perm
+        dst_fs.chmod(resolved_dst, perm)
 
         return dst_uri
 


### PR DESCRIPTION
# Fix copy validation and permission handling for `RemoteFileSystem` with a local `file://` base

> **Disclaimer:** This PR (analysis, fix, and MWE) was produced with the help of [Claude](https://claude.com/claude-code). It has been reviewed and verified by a human before being opened.

## Summary

`RemoteFileSystem._atomic_copy()` has two related bugs whenever the target filesystem's base uses a local `file://` scheme (e.g. a `WLCGFileSystem` configured with `base = file:///some/path`, a common setup for testing or for storage elements that are actually local/NFS/CephFS mounts):

1. It raises `Exception: validation failed after copying ...` even though the file was copied correctly.
2. Independently of validation, a configured `default_file_perm` is silently never applied to the copied file.

## Root cause

In `law/target/remote/base.py`, `_atomic_copy()` validates the copy and applies permissions like this:

```python
src_uri, dst_uri = self.file_interface.filecopy(src, dst, **kwargs)

# copy validation
dst_fs = self.local_fs if self.is_local(dst_uri) else self
if validate:
    if not dst_fs.exists(dst):
        raise Exception("validation failed after copying {} to {}".format(src_uri, dst_uri))

# handle permissions
if perm is None:
    perm = dst_fs.default_file_perm
dst_fs.chmod(dst, perm)
```

`dst` is relative to the remote filesystem's own base, while `dst_uri` is the fully resolved path (`dst` joined with that base).

When the destination is local, `dst_fs` becomes `self.local_fs` — a separate `LocalFileSystem` rooted at `/`, unrelated to the remote base. So `local_fs.exists(dst)` and `local_fs.chmod(dst, perm)` both resolve `dst` against the wrong root: `exists()` returns `False` even though the file is really there, and `chmod` silently no-ops (`LocalFileSystem.chmod` checks `exists()` first). `perm = dst_fs.default_file_perm` has the same problem — it's configured on the `wlcg_fs` section (`self`), not on the unrelated `local_fs`.

Genuinely remote destinations (`root://`, `srm://`, ...) don't hit this, since `dst_fs` stays `self` there and resolves everything against the real base — likely why it went unnoticed.

## Fix

Resolve the destination once — `dst_uri` when local, `dst` otherwise — and reuse it for both validation and `chmod`; read `default_file_perm` from `self` instead of `dst_fs`:

```python
# dst is base-relative, so use dst_uri instead when dst_fs is local_fs, which has its own,
# unrelated base
dst_is_local = self.is_local(dst_uri)
dst_fs = self.local_fs if dst_is_local else self
resolved_dst = dst_uri if dst_is_local else dst

# copy validation
if validate:
    if not dst_fs.exists(resolved_dst):
        raise Exception("validation failed after copying {} to {}".format(src_uri, dst_uri))

# handle permissions; default_file_perm belongs to self, not dst_fs
if perm is None:
    perm = self.default_file_perm
dst_fs.chmod(resolved_dst, perm)
```

## MWE

Reproduces both bugs (before the fix) and demonstrates success (after the fix): copies a local temp file to a `wlcg_fs` with a local `file://` base and a configured `default_file_perm`, then checks that the copy validates and that the permission was actually applied. Requires the `gfal` contrib's `gfal2` python bindings (e.g. via an LCG software stack). Run from the repository root:

```bash
python mwe.py
```

```python
"""
Standalone MWE for the bugs that occur when a RemoteFileSystem (e.g.
WLCGFileSystem via the gfal contrib) is configured with a local "file://"
base:

1. _atomic_copy() raises "validation failed after copying ..." even though
   the file was copied correctly.
2. Even when validation is disabled, a configured `default_file_perm` is
   silently never applied to the copied file (the chmod is a no-op).
"""
import os
import shutil
import stat
import tempfile

# a temp "storage element" backed by a plain local directory, configured
# *before* law is imported so no other law.cfg can interfere; also sets a
# default_file_perm to exercise the permission-handling bug
se_dir = tempfile.mkdtemp(prefix="law-mwe-se-")
cfg_path = tempfile.mktemp(prefix="law-mwe-", suffix=".cfg")
with open(cfg_path, "w") as f:
    f.write("[wlcg_fs]\nbase = file://{}\ndefault_file_perm = 0o0400\n".format(se_dir))
os.environ["LAW_CONFIG_FILE"] = cfg_path

import law  # noqa: E402

law.contrib.load("wlcg")

try:
    target = law.wlcg.WLCGFileTarget("mwe/test.txt", fs="wlcg_fs")

    tmp = law.LocalFileTarget(is_tmp="txt")
    tmp.touch()
    os.chmod(tmp.path, 0o0777)  # permissive mode, so a missing chmod is obvious afterwards

    print("copying {} -> {}".format(tmp.path, target.uri()))
    target.move_from_local(tmp)  # <-- raises "validation failed..." before the fix

    print("SUCCESS: move_from_local did not raise, and the file is really there:")
    real_path = os.path.join(se_dir, "mwe", "test.txt")
    print(" exists():", target.exists())
    print(" on disk :", os.path.exists(real_path))

    mode = stat.S_IMODE(os.stat(real_path).st_mode)
    print(" expected perm: 0o{:o}".format(0o0400))
    print(" actual perm  : 0o{:o}".format(mode))
    print(" permission " + ("MATCH" if mode == 0o0400 else "MISMATCH (chmod bug!)"))
finally:
    shutil.rmtree(se_dir, ignore_errors=True)
    os.remove(cfg_path)
```

### Before the fix

```
copying /tmp/luigi-tmp-939188812.txt -> file:///tmp/law-mwe-se-mt_5jnzt/mwe/test.txt
Traceback (most recent call last):
  ...
  File ".../law/target/remote/base.py", line 363, in _atomic_copy
    raise Exception("validation failed after copying {} to {}".format(src_uri, dst_uri))
Exception: validation failed after copying file:///tmp/luigi-tmp-939188812.txt to file:///tmp/law-mwe-se-mt_5jnzt/mwe/test.txt
```

(the file is nonetheless present on disk at `/tmp/law-mwe-se-mt_5jnzt/mwe/test.txt`; running again with `validate=False` shows the permission is also never applied — `0o755`/`0o777` instead of the configured `0o400`)

### After the fix

```
copying /tmp/luigi-tmp-316814757.txt -> file:///tmp/law-mwe-se-bx4zvl0i/mwe/test.txt
SUCCESS: move_from_local did not raise, and the file is really there:
 exists(): True
 on disk : True
 expected perm: 0o400
 actual perm  : 0o400
 permission MATCH
```
